### PR TITLE
Fix common style dependency.

### DIFF
--- a/includes/class-llms-blocks-assets.php
+++ b/includes/class-llms-blocks-assets.php
@@ -42,7 +42,7 @@ class LLMS_Blocks_Assets {
 		wp_enqueue_style(
 			'llms-blocks',
 			LLMS_BLOCKS_PLUGIN_DIR_URL . '/dist/blocks.style.build.css',
-			array( 'wp-blocks' ),
+			array( 'wp-block-library' ),
 			LLMS_BLOCKS_VERSION
 		);
 


### PR DESCRIPTION
`wp-blocks` is a script handle and not a style handle.

I'm not sure which is the best style handle to use from [`wp_default_styles()`](https://github.com/WordPress/WordPress/blob/5.2/wp-includes/script-loader.php#L2012). It looks like WooCommerce Blocks plugin [does not specify any dependencies](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/v2.0.1/assets/php/class-wgpb-block-library.php#L117) for it's common styles.