### PR TITLE
Fix form blocks errors in wp 5.3 beta nightly build

### DIFF
--- a/src/blocks/form-fields/settings.js
+++ b/src/blocks/form-fields/settings.js
@@ -179,14 +179,10 @@ const settings = {
 			block = getBlockType( name ),
 			{
 				clientId,
-				blockSettings,
 				setAttributes,
 			} = props,
-			inspectorSupports = blockSettings.supports.llms_field_inspector,
-			{
-				fillInspectorControls,
-				fillAdvancedInspectorControls,
-			} = blockSettings;
+			inspectorSupports = block.supports.llms_field_inspector,
+			{ fillInspectorControls } = block;
 
 		let { attributes } = props;
 		attributes = setup_atts( attributes, block.attributes );


### PR DESCRIPTION
bockSettings doesn't seem to be a property...
or at least not here, not sure why.

fix #35 