### PR TITLE
Updates to lesson progression block

### DIFF
--- a/assets/src/blocks/lesson-progression/editor.scss
+++ b/assets/src/blocks/lesson-progression/editor.scss
@@ -1,0 +1,7 @@
+.wp-block[data-type="llms/lesson-progression"] {
+	text-align: center;
+
+	button {
+		margin: 0 2px;
+	}
+}

--- a/assets/src/blocks/lesson-progression/index.js
+++ b/assets/src/blocks/lesson-progression/index.js
@@ -1,17 +1,21 @@
 /**
  * BLOCK: llms/lesson-progression
  *
- * @since   1.0.0
+ * @since 1.0.0
  * @since 1.5.0 Add supported post type settings.
+ * @since [version] Use imports in favor of "wp." variables.
+ *              Convert "edit" function from using ServerSideRender.
  */
 
-// WP Deps.
-const { ServerSideRender } = wp.components;
-const { Fragment } = wp.element
-const { __ } = wp.i18n;
+// CSS.
+import './editor.scss';
 
-// Import CSS.
-// import './editor.scss';
+// WP Deps.
+import { Button } from '@wordpress/components';
+import { select } from '@wordpress/data';
+import { applyFilters } from '@wordpress/hooks';
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Block Name
@@ -29,12 +33,7 @@ export const post_types = [ 'lesson' ];
 /**
  * Register Block
  *
- * @link https://wordpress.org/gutenberg/handbook/block-api/
- * @param  {string}   name     Block name.
- * @param  {Object}   settings Block settings.
- * @return {?WPBlock}          The block, if it has been successfully, registered; otherwise `undefined`.
- * @since   1.0.0
- * @version 1.0.0
+ * @type {Object}
  */
 export const settings = {
 	title: __( 'Lesson Progression (Mark Complete)', 'lifterlms' ),
@@ -42,56 +41,64 @@ export const settings = {
 		foreground: '#2295ff',
 		src: 'yes'
 	},
-	category: 'llms-blocks', // common, formatting, layout widgets, embed. see https://wordpress.org/gutenberg/handbook/block-api/#category.
+	category: 'llms-blocks',
 	keywords: [
 		__( 'LifterLMS', 'lifterlms' ),
 	],
+	supports: {
+		llms_visibility: false,
+	},
 
 	/**
-	 * The edit function describes the structure of your block in the context of the editor.
-	 * This represents what the editor will render when the block is used.
+	 * Edit block
 	 *
-	 * The "edit" property must be a valid function.
+	 * @since 1.0.0
 	 *
-	 * @link https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/
-	 * @param   {Object} props Block properties.
-	 * @return  {Function}
-	 * @since   1.0.0
-	 * @version 1.0.0
+	 * @param {Object} props Block properties.
+	 * @return {Function}
 	 */
 	edit: function( props ) {
-		const currentPost = wp.data.select( 'core/editor' ).getCurrentPost()
-		const {
-			attributes,
-			setAttributes,
-		} = props
+
+		const
+			{
+				attributes,
+				setAttributes,
+			}           = props,
+			currentPost = select( 'core/editor' ).getCurrentPost(),
+			quiz        = currentPost.meta._llms_quiz * 1;
+
+		let showMainBtn = quiz ? false : true;
+
+		/**
+		 * Determine whether or not to show the "Mark Complete" button in the lesson progression block editor "edit" view.
+		 *
+		 * @since [version]
+		 *
+		 * @param {Boolean} showMainBtn Determines whether or not to display the main button.
+		 */
+		showMainBtn = applyFilters( 'llms.lessonProgressBlock.showMainBtn', showMainBtn );
 
 		return (
 			<Fragment>
-				<ServerSideRender
-					block={ name }
-					attributes={ attributes }
-					urlQueryArgs={ {
-						post_id: currentPost.id
-					} }
-				/>
+				{ !!quiz && (
+					<Button className="llms-prog-btn--quiz" isPrimary>{ __( 'Take Quiz', 'lifterlms' ) }</Button>
+				) }
+				{ showMainBtn && (
+					<Button className="llms-prog-btn--complete" isPrimary>{ __( 'Mark Complete', 'lifterlms' ) }</Button>
+				) }
 			</Fragment>
 		);
 	},
 
 	/**
-	 * The save function defines the way in which the different attributes should be combined
-	 * into the final markup, which is then serialized by Gutenberg into post_content.
+	 * Save Block
 	 *
-	 * The "save" property must be specified and must be a valid function.
+	 * @since 1.0.0
 	 *
-	 * @link https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/
-	 * @param   {Object} props Block properties.
-	 * @return  {Function}
-	 * @since   1.0.0
-	 * @version 1.0.0
+	 * @param {Object} props Block properties.
+	 * @return {Function}
 	 */
 	save: function( props ) {
 		return null
 	},
-}
+};

--- a/includes/blocks/class-llms-blocks-lesson-progression-block.php
+++ b/includes/blocks/class-llms-blocks-lesson-progression-block.php
@@ -2,12 +2,12 @@
 /**
  * Lesson Progression block.
  *
+ * Render hook: llms_lesson-progression-block_render
+ *
  * @package  LifterLMS_Blocks/Blocks
  *
  * @since 1.0.0
- * @version 1.7.0
- *
- * @render_hook llms_lesson-progression-block_render
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -18,6 +18,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0
  * @since 1.1.0 Unknown
  * @since 1.7.0 Don't output an empty render message for free lessons.
+ * @since [version] Register meta data used by the block editor.
  */
 class LLMS_Blocks_Lesson_Progression_Block extends LLMS_Blocks_Abstract_Block {
 
@@ -38,11 +39,12 @@ class LLMS_Blocks_Lesson_Progression_Block extends LLMS_Blocks_Abstract_Block {
 	/**
 	 * Add actions attached to the render function action.
 	 *
-	 * @param   array  $attributes Optional. Block attributes. Default empty array.
-	 * @param   string $content    Optional. Block content. Default empty string.
-	 * @return  void
-	 * @since   1.0.0
-	 * @version 1.1.0
+	 * @since 1.0.0
+	 * @since 1.1.0 Unknown.
+	 *
+	 * @param array  $attributes Optional. Block attributes. Default empty array.
+	 * @param string $content    Optional. Block content. Default empty string.
+	 * @return void
 	 */
 	public function add_hooks( $attributes = array(), $content = '' ) {
 
@@ -69,9 +71,9 @@ class LLMS_Blocks_Lesson_Progression_Block extends LLMS_Blocks_Abstract_Block {
 	 * Retrieve custom block attributes.
 	 * Necessary to override when creating ServerSideRender blocks.
 	 *
-	 * @return  array
-	 * @since   1.0.0
-	 * @version 1.0.0
+	 * @since 1.0.0
+	 *
+	 * @return array
 	 */
 	public function get_attributes() {
 		return array_merge(
@@ -83,6 +85,32 @@ class LLMS_Blocks_Lesson_Progression_Block extends LLMS_Blocks_Abstract_Block {
 				),
 			)
 		);
+	}
+
+	/**
+	 * Register meta attributes.
+	 *
+	 * Called after registering the block type.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function register_meta() {
+
+		register_meta(
+			'post',
+			'_llms_quiz',
+			array(
+				'object_subtype'    => 'lesson',
+				'sanitize_callback' => 'absint',
+				'auth_callback'     => '__return_true',
+				'type'              => 'string',
+				'single'            => true,
+				'show_in_rest'      => true,
+			)
+		);
+
 	}
 
 }

--- a/includes/blocks/class-llms-blocks-lesson-progression-block.php
+++ b/includes/blocks/class-llms-blocks-lesson-progression-block.php
@@ -69,6 +69,7 @@ class LLMS_Blocks_Lesson_Progression_Block extends LLMS_Blocks_Abstract_Block {
 
 	/**
 	 * Retrieve custom block attributes.
+	 * 
 	 * Necessary to override when creating ServerSideRender blocks.
 	 *
 	 * @since 1.0.0


### PR DESCRIPTION
## Description

Switched block edit to output content dynamically instead of using serverSideRender.
This adds a slight performance increase but also allows us to (in the future) do realtime editing of the block's information (and related information) much much easier. In the future I could see converting the button text to richText components and storing that as metadata on the block that can be used to easily customize the button of the text on the frontend. We could easily add button size, color, etc... options. Furthermore, we could add settings to add a quiz (and other elements) to the lesson via the block editor. This would help us transition out of metaboxes and allow users who do not want to use the course builder to add settings simply.

This also fixes #23 by defining that this block *does not support* block visibility.

Since the server will continue to render content on the front-end of the website these changes affect only the view within the block editor. On the frontend nothing changes.

The fix for #23 fixes a UX issue where users could create a confusing experience for themselves since the visibility display is handled automatically on the server and doesn't require the visibility settings to be set by the user. Nothing actually changes on the frontend.

## How has this been tested?

I've run manual tests for all possible scenarios to ensure this doesn't break anything. See screenshot for view of different possible states

## Screenshots <!-- if applicable -->

![Screenshot_2020-04-24_16-43-50](https://user-images.githubusercontent.com/1290739/80264976-d6f05d00-864a-11ea-9c6a-7f4914bc1550.png)

## Types of changes

Minor issue: since this removes the server-side render of the block on the admin panel the "assignment" button will not display without an update to the assignments plugin. The code to add the button to the block editor via JS is here: https://github.com/gocodebox/lifterlms-assignments/pull/38

So if a user upgrades LifterLMS and NOT LifterLMS Assignments it will appears as if they've lost their assignment (but only in the editor). We can make a note of this in the changelog and as long as the support team is aware of this potential issue not much harm will actually be done.


## Checklist:

- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

