### PR TITLE
merge visibility attributes

### DIFF
--- a/assets/src/block-visibility/attributes.js
+++ b/assets/src/block-visibility/attributes.js
@@ -4,10 +4,41 @@
  * @since 1.0.0
  * @since 1.5.1 Exits early for non LifterLMS dynamic blocks.
  * @since 1.6.0 Setup visibility support checking as a module.
- * @version 1.6.0
+ * @since [version] Merge default values into block settings.
  */
 
+// Internal deps.
 import check from './check';
+
+/**
+ * Setup attribute settings for a given attribute.
+ *
+ * This merges our default attribute settings with existing attribute settings
+ * if they exist, allowing blocks to register their own custom visibility defaults.
+ *
+ * Note: the attribute *type* will always be overwritten even if it's defined in the block.
+ * This is done to ensure that our internal logic for handling enrollment data isn't broken.
+ *
+ * @since [version]
+ *
+ * @param {Object} attributes    Block settings.attributes object.
+ * @param {String} attributeName Visibility attribute name.
+ * @param {Object} defaults      Visibility attribute default values.
+ * @return {Object}
+ */
+const setAttribute = ( attributes, attributeName, defaults ) => {
+
+	// Default is already set, ensure type is set.
+	if ( attributes[ attributeName ] && attributes[ attributeName ].default ) {
+		attributes[ attributeName ].type = defaults.type;
+	} else {
+		attributes[ attributeName ] = defaults;
+	}
+
+	return attributes;
+
+};
+
 
 /**
  * Add visibility settings to qualifying blocks.
@@ -15,6 +46,7 @@ import check from './check';
  * Block registration filter callback.
  *
  * @since 1.0.0
+ * @since [version] Merge default values into block settings.
  *
  * @param {object} settings Block settings object.
  * @param {string} name Block name, eg "core/paragraph".
@@ -30,18 +62,24 @@ export default function visibilityAttributes( settings, name ) {
 		settings.attributes = {};
 	}
 
-	settings.attributes.llms_visibility = {
-		default: 'all',
-		type: 'string',
-	}
-	settings.attributes.llms_visibility_in = {
-		default: '',
-		type: 'string',
-	}
-	settings.attributes.llms_visibility_posts = {
-		type: 'string',
-		default: '[]',
-	}
+	const visibilityAttributes = {
+		llms_visibility: {
+			default: 'all',
+			type: 'string',
+		},
+		llms_visibility_in: {
+			default: '',
+			type: 'string',
+		},
+		llms_visibility_posts: {
+			default: '[]',
+			type: 'string',
+		},
+	};
+
+	Object.keys( visibilityAttributes ).forEach( key => {
+		settings.attributes = setAttribute( settings.attributes, key, visibilityAttributes[ key ] );
+	} );
 
 	return settings
 


### PR DESCRIPTION
## Description

Minor change to preemptively fix an issue I saw while working on #23 

If a block wants to register a custom default value for any of our block visibility attributes it will be overwritten by our default value.

This PR changes that behavior to only set the default value if it's not already defined for the setting.

## How has this been tested?

Added a visibility default value to a block and then created a new block to ensure the default value stuck

Also checked other blocks to ensure the actual defaults were intact when not adding custom defaults to the block.

## Types of changes

Non-breaking preemptive "bug" fix (is it a bug if no one's reported it?)

## Checklist:

- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

