### PR TITLE
Fix spelling error

### DIFF
--- a/includes/blocks/class-llms-blocks-instructors-block.php
+++ b/includes/blocks/class-llms-blocks-instructors-block.php
@@ -2,18 +2,22 @@
 /**
  * Instructors block.
  *
- * @package  LifterLMS_Blocks/Blocks
+ * Render hook: llms_instructors-block_render
  *
- * @since    1.0.0
- * @version  1.1.0
+ * @package LifterLMS_Blocks/Blocks
  *
- * @render_hook llms_instructors-block_render
+ * @since 1.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Course syllabus block class.
+ *
+ * @since 1.0.0
+ * @since 1.1.0 Unknown.
+ * @since [version] Fixed a spelling error.
  */
 class LLMS_Blocks_Instructors_Block extends LLMS_Blocks_Abstract_Block {
 
@@ -34,11 +38,12 @@ class LLMS_Blocks_Instructors_Block extends LLMS_Blocks_Abstract_Block {
 	/**
 	 * Add actions attached to the render function action.
 	 *
-	 * @param   array  $attributes Optional. Block attributes. Default empty array.
-	 * @param   string $content    Optional. Block content. Default empty string.
-	 * @return  void
-	 * @since   1.0.0
-	 * @version 1.1.0
+	 * @since 1.0.0
+	 * @since 1.1.0 Unknown.
+	 *
+	 * @param array  $attributes Optional. Block attributes. Default empty array.
+	 * @param string $content    Optional. Block content. Default empty string.
+	 * @return void
 	 */
 	public function add_hooks( $attributes = array(), $content = '' ) {
 
@@ -48,11 +53,12 @@ class LLMS_Blocks_Instructors_Block extends LLMS_Blocks_Abstract_Block {
 
 	/**
 	 * Retrieve custom block attributes.
+	 *
 	 * Necessary to override when creating ServerSideRender blocks.
 	 *
-	 * @return  array
-	 * @since   1.0.0
-	 * @version 1.0.0
+	 * @since 1.0.0
+	 *
+	 * @return array
 	 */
 	public function get_attributes() {
 		return array_merge(
@@ -69,12 +75,13 @@ class LLMS_Blocks_Instructors_Block extends LLMS_Blocks_Abstract_Block {
 	/**
 	 * Output a message when no HTML was rendered
 	 *
-	 * @return  string
-	 * @since   1.0.0
-	 * @version 1.0.0
+	 * @since 1.0.0
+	 * @since [version] Fixed spelling error.
+	 *
+	 * @return string
 	 */
 	public function get_empty_render_message() {
-		return __( 'No visibile instructors were found.', 'lifterlms' );
+		return __( 'No visible instructors were found.', 'lifterlms' );
 	}
 
 }

--- a/includes/blocks/class-llms-blocks-lesson-progression-block.php
+++ b/includes/blocks/class-llms-blocks-lesson-progression-block.php
@@ -69,7 +69,7 @@ class LLMS_Blocks_Lesson_Progression_Block extends LLMS_Blocks_Abstract_Block {
 
 	/**
 	 * Retrieve custom block attributes.
-	 * 
+	 *
 	 * Necessary to override when creating ServerSideRender blocks.
 	 *
 	 * @since 1.0.0


### PR DESCRIPTION
## Description

Fixes #57

## How has this been tested?

Unit tests pass

## Screenshots <!-- if applicable -->


## Types of changes

Spelling fix.

## Checklist:

- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

