### PR TITLE
Use different render functions depending on the post type

### DIFF
--- a/includes/blocks/class-llms-blocks-instructors-block.php
+++ b/includes/blocks/class-llms-blocks-instructors-block.php
@@ -7,7 +7,7 @@
  * @package LifterLMS_Blocks/Blocks
  *
  * @since 1.0.0
- * @version 1.8.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -16,8 +16,6 @@ defined( 'ABSPATH' ) || exit;
  * Course syllabus block class.
  *
  * @since 1.0.0
- * @since 1.1.0 Unknown.
- * @since 1.8.0 Fixed a spelling error.
  */
 class LLMS_Blocks_Instructors_Block extends LLMS_Blocks_Abstract_Block {
 
@@ -40,6 +38,7 @@ class LLMS_Blocks_Instructors_Block extends LLMS_Blocks_Abstract_Block {
 	 *
 	 * @since 1.0.0
 	 * @since 1.1.0 Unknown.
+	 * @since [version] Add support for memberships.
 	 *
 	 * @param array  $attributes Optional. Block attributes. Default empty array.
 	 * @param string $content    Optional. Block content. Default empty string.
@@ -47,7 +46,20 @@ class LLMS_Blocks_Instructors_Block extends LLMS_Blocks_Abstract_Block {
 	 */
 	public function add_hooks( $attributes = array(), $content = '' ) {
 
-		add_action( $this->get_render_hook(), 'lifterlms_template_course_author', 10 );
+		switch ( get_post_type() ) {
+			case 'course':
+				$func = 'lifterlms_template_course_author';
+				break;
+
+			case 'llms_membership':
+				$func = 'llms_template_membership_instructors';
+				break;
+
+			default:
+				return;
+		}
+
+		add_action( $this->get_render_hook(), $func, 10 );
 
 	}
 


### PR DESCRIPTION
## Description

+ Continues #75 and https://github.com/gocodebox/lifterlms/pull/1466

Uses a different template function depending on the current post type.

## How has this been tested?

+ Manually

## Screenshots <!-- if applicable -->


## Types of changes

+ Updates

## Checklist:

- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

