### PR TITLE
Various fixes for checkboxes and radio buttons

### DIFF
--- a/src/js/blocks/form-fields/editor.scss
+++ b/src/js/blocks/form-fields/editor.scss
@@ -22,11 +22,13 @@
 
 	input {
 		border: 1px solid #999;
-		border-radius: 4px;
 		padding: 4px 8px;
 		&:focus::placeholder {
 			opacity: 0;
 		}
+	}
+	input:not([type=radio]) {
+		border-radius: 4px;
 	}
 
 	.llms-field {

--- a/src/js/blocks/form-fields/fields/checkboxes.js
+++ b/src/js/blocks/form-fields/fields/checkboxes.js
@@ -3,6 +3,7 @@
  *
  * @since 1.6.0
  * @since 1.12.0 Add transform support and default options.
+ * @since [version] Added default keys.
  */
 
 // WP Deps.
@@ -56,10 +57,12 @@ settings.attributes.options.__default = [
 	{
 		default: 'no',
 		text: __( 'Option 1', 'lifterlms' ),
+		key: __( 'option_1', 'lifterlms' ),
 	},
 	{
 		default: 'no',
 		text: __( 'Option 2', 'lifterlms' ),
+		key: __( 'option_2', 'lifterlms' ),
 	},
 ];
 

--- a/src/js/blocks/form-fields/fields/radio.js
+++ b/src/js/blocks/form-fields/fields/radio.js
@@ -62,7 +62,7 @@ settings.attributes.options.__default = [
 	{
 		default: 'no',
 		text: __( 'Option 2', 'lifterlms' ),
-		key: __( 'option_1', 'lifterlms' ),
+		key: __( 'option_2', 'lifterlms' ),
 	},
 ];
 

--- a/src/js/blocks/form-fields/fields/radio.js
+++ b/src/js/blocks/form-fields/fields/radio.js
@@ -3,6 +3,7 @@
  *
  * @since 1.6.0
  * @since 1.12.0 Add transform support and default options.
+ * @since [version] Add default keys.
  */
 
 // WP Deps.
@@ -56,10 +57,12 @@ settings.attributes.options.__default = [
 	{
 		default: 'yes',
 		text: __( 'Option 1', 'lifterlms' ),
+		key: __( 'option_1', 'lifterlms' ),
 	},
 	{
 		default: 'no',
 		text: __( 'Option 2', 'lifterlms' ),
+		key: __( 'option_1', 'lifterlms' ),
 	},
 ];
 

--- a/src/js/blocks/form-fields/inspect-field-options.js
+++ b/src/js/blocks/form-fields/inspect-field-options.js
@@ -302,7 +302,7 @@ export default class InspectorFieldOptions extends Component {
 		 */
 		const onOptionChange = ( option, index ) => {
 			const prevOption = options[ index ] ? options[ index ] : false,
-				  {field}    = this.props.attributes;
+				  { field }    = this.props.attributes;
 
 			options[ index ] = option;
 			this.updateOptions( options );


### PR DESCRIPTION
## Description


Fixes for https://github.com/gocodebox/lifterlms/issues/1577
bullets:

> 1 - radio buttons in the editor look like checkboxes - so squared and with a small border radius, it’s because of our CSS that applies a small border radius to all the fields
> 2 - checkboxes: it’s not possible to remove a default option once set (in the right panel)
> 3 - checkboxes in the right panel look like radio buttons, and they shouldn’t, also you can check only one option by default, and this doesn’t make a lot of sense for checkboxes
> 8 - When you Show keys of the default two options for both radio and checkboxes the "saved values" are empty.

## How has this been tested?
Manually.

## Screenshots <!-- if applicable -->


## Types of changes

Bug fix (non-breaking change which fixes an issue) 

## Checklist:

- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

