### PR TITLE
Lesson progression fix

### DIFF
--- a/includes/blocks/class-llms-blocks-lesson-progression-block.php
+++ b/includes/blocks/class-llms-blocks-lesson-progression-block.php
@@ -61,7 +61,7 @@ class LLMS_Blocks_Lesson_Progression_Block extends LLMS_Blocks_Abstract_Block {
 	 */
 	public function get_empty_render_message() {
 		$lesson = llms_get_post( get_the_ID() );
-		if ( $lesson && is_a($lesson, 'LLMS_Lesson') && $lesson->is_free() ) {
+		if ( $lesson && is_a( $lesson, 'LLMS_Lesson' ) && $lesson->is_free() ) {
 			return '';
 		}
 		return parent::get_empty_render_message();

--- a/includes/blocks/class-llms-blocks-lesson-progression-block.php
+++ b/includes/blocks/class-llms-blocks-lesson-progression-block.php
@@ -61,7 +61,7 @@ class LLMS_Blocks_Lesson_Progression_Block extends LLMS_Blocks_Abstract_Block {
 	 */
 	public function get_empty_render_message() {
 		$lesson = llms_get_post( get_the_ID() );
-		if ( $lesson && $lesson->is_free() ) {
+		if ( $lesson && is_a($lesson, 'LLMS_Lesson') && $lesson->is_free() ) {
 			return '';
 		}
 		return parent::get_empty_render_message();

--- a/package-lock.json
+++ b/package-lock.json
@@ -3965,9 +3965,9 @@
       "dev": true
     },
     "bl": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dev": true,
       "requires": {
         "buffer": "^5.5.0",
@@ -5881,24 +5881,24 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
           "dev": true
         }
       }
@@ -16523,9 +16523,9 @@
       }
     },
     "tar-stream": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "requires": {
         "bl": "^4.0.3",


### PR DESCRIPTION
## Description

In the class `LLMS_Blocks_Lesson_Progression_Block` method `get_empty_render_message()` there is a conditional statement that checks if a lesson is free.  However, there can be instances where the current post (as returned by `get_the_ID()`) is not actually a lesson.  The block may be inside a widget or shortcode on a course or regular WordPress page.  This would result in the error:

```
PHP Fatal error:  Uncaught Error: Call to undefined method LLMS_Course::is_free() in /path/to/wordpress/wp-content/plugins/lifterlms/vendor/lifterlms/lifterlms-blocks/includes/blocks/class-llms-blocks-lesson-progression-block.php:64
```

To prevent the error from being thrown, I added `is_a($lesson, 'LLMS_Lesson')` in the conditional statement before the existing call to `$lesson->is_free()`.

## How has this been tested?

The updated code is working fine on my website that uses LifterLMS (https://davidmolnar.com).  The specific place where the error occurred is fixed by this change.

## Types of changes

This update does not change the logic of the code, because the original code was already checking to see if `$lesson` is truthy in case the post could not be retrieved at all.  With my change, if `$lesson` is not an instance of `LLMS_Lesson`, it behaves the same way as if no post could be retrieved.

## Checklist:

- [X] My code has been tested.
- [ ] My code passes all existing automated tests.
- [X] My code follows the LifterLMS Coding & Documentation Standards.

