### PR TITLE
Fix format type name with wp nightly (5.8)

### DIFF
--- a/src/js/formats/shortcodes/index.js
+++ b/src/js/formats/shortcodes/index.js
@@ -14,7 +14,7 @@ import { default as Edit } from './edit';
 import { __ } from '@wordpress/i18n';
 import { registerFormatType } from '@wordpress/rich-text';
 
-registerFormatType( 'llms/userInfoShortcodes', {
+registerFormatType( 'llms/user-info-shortcodes', {
 	title: __( 'LifterLMS User Information Shortcodes', 'lifterlms' ),
 	tagName: 'span',
 	className: 'llms-user-sc-wrap',


### PR DESCRIPTION
## Description

The new shortcodes options didn't appear in the rich text editor.
I found it to be an issue, at least, with wp nightly build (and then 5.8).
This is the js error I could see logged in the console:
```
Format names must contain a namespace prefix, include only lowercase alphanumeric characters or dashes, and start with a letter. Example: my-plugin/my-custom-format
registerFormatType @ rich-text.js?ver=7ab2606616750166b2e3fa1e80bb82ca:1883
```

## How has this been tested?

Manually

## Screenshots <!-- if applicable -->


## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

