### PR TITLE
Stop password strength meter option controlling password length option visibility

### DIFF
--- a/src/js/blocks/form-fields/fields/user-password.js
+++ b/src/js/blocks/form-fields/fields/user-password.js
@@ -108,10 +108,6 @@ const fillInspectorControls = ( attributes, setAttributes ) => {
 			{ meter && (
 				<SelectControl
 					label={ __( 'Minimum Password Strength', 'lifterlms' ) }
-					help={ __(
-						"Display in the meter's description with: {min_strength}.",
-						'lifterlms'
-					) }
 					value={ min_strength }
 					onChange={ ( min_strength ) =>
 						setAttributes( { min_strength } )
@@ -126,10 +122,6 @@ const fillInspectorControls = ( attributes, setAttributes ) => {
 
 			<TextControl
 				label={ __( 'Minimum Password Length', 'lifterlms' ) }
-				help={ __(
-					"Display in the meter's description with: {min_length}.",
-					'lifterlms'
-				) }
 				value={ minlength }
 				type="number"
 				min="6"
@@ -206,14 +198,9 @@ export const settings = getSettingsFromBase(
 			},
 			meter_description: {
 				type: 'string',
-				__default: sprintf(
-					// Translators: %1$s = Min strength merge code; %2$s = min length merge code.
-					__(
-						'A %1$s password is required with at least %2$s characters. To make it stronger, use both upper and lower case letters, numbers, and symbols.',
-						'lifterlms'
-					),
-					'{min_strength}',
-					'{min_length}'
+				__default: __(
+					'A strong password is required with at least 8 characters. To make it stronger, use both upper and lower case letters, numbers, and symbols.',
+					'lifterlms'
 				),
 			},
 			min_strength: {

--- a/src/js/blocks/form-fields/fields/user-password.js
+++ b/src/js/blocks/form-fields/fields/user-password.js
@@ -124,26 +124,25 @@ const fillInspectorControls = ( attributes, setAttributes ) => {
 				/>
 			) }
 
-			{ meter && (
-				<TextControl
-					label={ __( 'Minimum Password Length', 'lifterlms' ) }
-					help={ __(
-						"Display in the meter's description with: {min_length}.",
-						'lifterlms'
-					) }
-					value={ minlength }
-					type="number"
-					min="6"
-					onChange={ ( val ) =>
-						setAttributes( {
-							html_attrs: {
-								...html_attrs,
-								minlength: val * 1,
-							},
-						} )
-					}
-				/>
-			) }
+			<TextControl
+				label={ __( 'Minimum Password Length', 'lifterlms' ) }
+				help={ __(
+					"Display in the meter's description with: {min_length}.",
+					'lifterlms'
+				) }
+				value={ minlength }
+				type="number"
+				min="6"
+				onChange={ ( val ) =>
+					setAttributes( {
+						html_attrs: {
+							...html_attrs,
+							minlength: val * 1,
+						},
+					} )
+				}
+			/>
+
 		</Fragment>
 	);
 };


### PR DESCRIPTION
## Description

Fixes #101
I thought about changing the `help` to `"Display in the descriptions with: {min_length}."` hence replacing the `{min_length}` in the password field to (to be done in core), but I'm not sure about that. What do you think @thomasplevy ?

## How has this been tested?

manually

## Screenshots <!-- if applicable -->
n/a

## Types of changes

 Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

