### PR TITLE
Don't pull `name` from undefined object

### DIFF
--- a/src/js/blocks/form-fields/fields/confirm-group.js
+++ b/src/js/blocks/form-fields/fields/confirm-group.js
@@ -185,7 +185,7 @@ allowed.forEach( ( blockName ) => {
 				{ innerBlocks } = getSelectedBlock(),
 				controllerBlock =
 					innerBlocks[ findControllerBlockIndex( innerBlocks ) ],
-				{ name } = controllerBlock;
+				{ name } = controllerBlock || {};
 
 			return name === blockName;
 		},


### PR DESCRIPTION
## Description

Fixes #99

## How has this been tested?

Manually

## Types of changes

Bug fix

## Checklist:

- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

