### PR TITLE
Fix compatibility with wp 5.8

### DIFF
--- a/includes/class-llms-blocks.php
+++ b/includes/class-llms-blocks.php
@@ -96,13 +96,14 @@ class LLMS_Blocks {
 	 * @link https://github.com/gocodebox/lifterlms-blocks/issues/30
 	 *
 	 * @since 1.5.1
+	 * @since [version] Since WordPress 5.8 blocks are available in widgets and customizer screen too.
 	 *
 	 * @return void
 	 */
 	public function admin_print_scripts() {
 
 		$screen = get_current_screen();
-		if ( ! $screen || 'post' !== $screen->base ) {
+		if ( ! $screen || ( empty( $screen->is_block_editor ) && 'customizer' !== $screen ) ) {
 			return;
 		}
 

--- a/includes/class-llms-blocks.php
+++ b/includes/class-llms-blocks.php
@@ -103,7 +103,7 @@ class LLMS_Blocks {
 	public function admin_print_scripts() {
 
 		$screen = get_current_screen();
-		if ( ! $screen || ( empty( $screen->is_block_editor ) && 'customizer' !== $screen ) ) {
+		if ( ! $screen || ( empty( $screen->is_block_editor ) && 'customize' !== $screen->base ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## Description

Fixes Appearance->Widgets blank screen.
Additionally fix for the customizer as well.

I didn't test 5.8 thoroughly just wanted to fix this so that we can use the widgets screen.

## How has this been tested?

manually

## Screenshots <!-- if applicable -->


## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

