### PR TITLE
Filter reusable core field blocks from widgets screen

### DIFF
--- a/tests/phpunit/unit-tests/class-llms-blocks-test-reusable.php
+++ b/tests/phpunit/unit-tests/class-llms-blocks-test-reusable.php
@@ -108,30 +108,41 @@ class LLMS_Blocks_Test_Reusable extends LLMS_Blocks_Unit_Test_Case {
 		$res = $this->main->mod_wp_block_query( $args, $request );
 		$this->assertEquals( $expect, $res );
 
-		// From any other post.
-		$post = $this->factory->post->create();
-		$request->set_header( 'referer', get_edit_post_link( $post ) );
 
-		$expect = array(
-			'input',
-			'meta_query' => array(
-				'relation' => 'AND',
-				array(
-					'relation' => 'OR',
+		// From any other post or the widgets screen.
+		$tests = array(
+			get_edit_post_link( $this->factory->post->create() ),
+			get_edit_post_link( $this->factory->post->create( array( 'post_type' => 'course' ) ) ),
+			get_edit_post_link( $this->factory->post->create( array( 'post_type' => 'page' ) ) ),
+			'https://example.tld/wp-admin/widgets.php',
+		);
+
+		foreach ( $tests as $test ) {
+
+			$request->set_header( 'referer', $test );
+
+			$expect = array(
+				'input',
+				'meta_query' => array(
+					'relation' => 'AND',
 					array(
-						'key' => '_is_llms_field',
-						'value' => 'yes',
-						'compare' => '!=',
-					),
-					array(
-						'key' => '_is_llms_field',
-						'compare' => 'NOT EXISTS',
+						'relation' => 'OR',
+						array(
+							'key' => '_is_llms_field',
+							'value' => 'yes',
+							'compare' => '!=',
+						),
+						array(
+							'key' => '_is_llms_field',
+							'compare' => 'NOT EXISTS',
+						),
 					),
 				),
-			),
-		);
-		$res = $this->main->mod_wp_block_query( $args, $request );
-		$this->assertEquals( $expect, $res );
+			);
+			$res = $this->main->mod_wp_block_query( $args, $request );
+			$this->assertEquals( $expect, $res );
+
+		}
 
 	}
 


### PR DESCRIPTION
## Description

Prevents reusable blocks with LifterLMS field blocks from being used on the WP 5.8 widgets screen

Fixes #111

## How has this been tested?

+ Manually
+ Existing phpunit test
+ New phpunit test to cover added scenarios

## Screenshots <!-- if applicable -->


## Types of changes

WP 5.8 compat

## Checklist:

- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

