### PR TITLE
Ensure block editor assets are not enqueued on the blockified widgets screen in wp 5.8

### DIFF
--- a/includes/class-llms-blocks-assets.php
+++ b/includes/class-llms-blocks-assets.php
@@ -7,7 +7,7 @@
  * @package LifterLMS_Blocks/Main
  *
  * @since 1.0.0
- * @version 2.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -137,6 +137,7 @@ class LLMS_Blocks_Assets {
 	 * @since 1.8.0 Update asset paths and improve script dependencies.
 	 * @since 1.10.0 Use `LLMS_Assets` class methods for asset enqueues.
 	 * @since 2.0.0 Maybe load backwards compatibility script.
+	 * @since [version] Only load assets on post screens.
 	 *
 	 * @return void
 	 */

--- a/includes/class-llms-blocks-assets.php
+++ b/includes/class-llms-blocks-assets.php
@@ -142,6 +142,11 @@ class LLMS_Blocks_Assets {
 	 */
 	public function editor_assets() {
 
+		$screen = get_current_screen();
+		if ( $screen && 'post' !== $screen->base ) {
+			return;
+		}
+
 		if ( $this->use_bc_assets() ) {
 			$this->assets->enqueue_script( 'llms-blocks-editor-bc' );
 		}

--- a/tests/phpunit/unit-tests/class-llms-blocks-test-assets.php
+++ b/tests/phpunit/unit-tests/class-llms-blocks-test-assets.php
@@ -50,9 +50,35 @@ class LLMS_Blocks_Test_Assets extends LLMS_Blocks_Unit_Test_Case {
 	}
 
 	/**
+	 * Test editor_assets() on the widgets screen where they shouldn't be loaded.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_editor_assets_widgets_screen() {
+
+		$main = new LLMS_Blocks_Assets();
+		$this->deregister_assets();
+
+		$this->assertAssetNotEnqueued( 'script', 'llms-blocks-editor' );
+		$this->assertAssetNotEnqueued( 'style', 'llms-blocks-editor' );
+
+		set_current_screen( 'widgets' );
+		$main->editor_assets();
+
+		$this->assertAssetNotEnqueued( 'script', 'llms-blocks-editor' );
+		$this->assertAssetNotEnqueued( 'style', 'llms-blocks-editor' );
+
+		set_current_screen( 'front' );
+
+	}
+
+	/**
 	 * Test editor_assets()
 	 *
 	 * @since 1.10.0
+	 * @since [version] Set current screen.
 	 *
 	 * @return void
 	 */
@@ -64,10 +90,13 @@ class LLMS_Blocks_Test_Assets extends LLMS_Blocks_Unit_Test_Case {
 		$this->assertAssetNotEnqueued( 'script', 'llms-blocks-editor' );
 		$this->assertAssetNotEnqueued( 'style', 'llms-blocks-editor' );
 
+		set_current_screen( 'post' );
 		$main->editor_assets();
 
 		$this->assertAssetIsEnqueued( 'script', 'llms-blocks-editor' );
 		$this->assertAssetIsEnqueued( 'style', 'llms-blocks-editor' );
+
+		set_current_screen( 'front' );
 
 	}
 
@@ -75,10 +104,13 @@ class LLMS_Blocks_Test_Assets extends LLMS_Blocks_Unit_Test_Case {
 	 * Test backwards compat asset define and enqueue
 	 *
 	 * @since 2.0.0
+	 * @since [version] Set current screen.
 	 *
 	 * @return void
 	 */
 	public function test_backwards_compat_assets() {
+
+		set_current_screen( 'post' );
 
 		wp_dequeue_script( 'llms-blocks-editor-bc' );
 
@@ -102,6 +134,8 @@ class LLMS_Blocks_Test_Assets extends LLMS_Blocks_Unit_Test_Case {
 		$this->assertAssetIsEnqueued( 'script', 'llms-blocks-editor-bc' );
 
 		$wp_version = $temp;
+
+		set_current_screen( 'front' );
 
 	}
 


### PR DESCRIPTION
## How has this been tested?

Manually
Existing tests (modified)
New tests

## Screenshots <!-- if applicable -->


## Types of changes

WP 5.8 compat

## Checklist:

- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

