### PR TITLE
Revert "Handle '-src' in WordPress version numbers in `LLMS_Blocks::init()`."

### DIFF
--- a/includes/class-llms-blocks.php
+++ b/includes/class-llms-blocks.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_Blocks/Classes
  *
  * @since 1.0.0
- * @version [version]
+ * @version 2.0.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -14,7 +14,6 @@ defined( 'ABSPATH' ) || exit;
  * LLMS_Blocks class
  *
  * @since 1.0.0
- * @since [version] Handle '-src' in WordPress version numbers in `init()`.
  */
 class LLMS_Blocks {
 
@@ -156,7 +155,6 @@ class LLMS_Blocks {
 	 * @since 1.9.0 Added course progress block class.
 	 * @since 2.0.0 Return early if LifterLMS isn't installed, move file inclusion to `$this->includes()`,
 	 *              and moved actions and filters from the constructor.
-	 * @since [version] Handle '-src' in WordPress version numbers.
 	 *
 	 * @return  void
 	 */
@@ -171,7 +169,7 @@ class LLMS_Blocks {
 		add_action( 'add_meta_boxes', array( $this, 'remove_metaboxes' ), 999, 2 );
 
 		global $wp_version;
-		$filter = version_compare( $wp_version, '5.8-src', '>=' ) ? 'block_categories_all' : 'block_categories';
+		$filter = version_compare( $wp_version, '5.8-alpha.1', '>=' ) ? 'block_categories_all' : 'block_categories';
 
 		add_filter( $filter, array( $this, 'add_block_category' ) );
 		add_action( 'admin_print_scripts', array( $this, 'admin_print_scripts' ), 15 );

--- a/tests/phpunit/unit-tests/class-llms-blocks-test-blocks.php
+++ b/tests/phpunit/unit-tests/class-llms-blocks-test-blocks.php
@@ -7,7 +7,7 @@
  * @since 1.5.1
  * @since 1.6.0 Update `test_add_block_category` test to accommodate form fields cat.
  * @since 1.10.0 Update `test_get_dynamic_block_names` to test against core blocks available in 5.1.
- * @version [version]
+ * @version 2.0.0
  */
 class LLMS_Blocks_Test_Blocks extends LLMS_Blocks_Unit_Test_Case {
 
@@ -158,77 +158,6 @@ class LLMS_Blocks_Test_Blocks extends LLMS_Blocks_Unit_Test_Case {
 
 		}
 
-	}
-
-	/**
-	 * Test that `LLMS_Blocks->init()` adds the correct block category filter.
-	 *
-	 * @since [version]
-	 *
-	 * @return void
-	 */
-	public function test_add_block_category_filter() {
-
-		global $wp_version;
-		$blocks   = new LLMS_Blocks();
-		$callback = array( $blocks, 'add_block_category' );
-
-		# LLMS_Blocks->add_block_category() should not be registered as a filter yet.
-		$this->assertFalse( has_filter( 'block_categories', $callback ) );
-		$this->assertFalse( has_filter( 'block_categories_all', $callback ) );
-
-		# Test WordPress version < 5.8
-		$wp_versions = array(
-			'5.7-alpha-49644-src',
-			'5.7-alpha.1',
-			'5.7-beta1-src',
-			'5.7-beta1',
-			'5.7-beta1-50172-src',
-			'5.7-RC1-src',
-			'5.7-RC1',
-			'5.7-RC1-50425-src',
-			'5.7-src',
-			'5.7',
-			'5.7.1-alpha-50514-src',
-			'5.7.1-src',
-			'5.7.1',
-		);
-		foreach ( $wp_versions as $wp_version ) {
-			$blocks->init();
-			$this->assertNotFalse( has_filter( 'block_categories', $callback ), $wp_version );
-			$this->assertFalse( has_filter( 'block_categories_all', $callback ), $wp_version );
-			remove_filter( 'block_categories', $callback );
-			remove_filter( 'block_categories_all', $callback );
-		}
-
-		# Test WordPress version >= 5.8
-		$wp_versions = array(
-			'5.8-alpha-50427-src',
-			'5.8-alpha.1',
-			'5.8-beta1-src',
-			'5.8-beta1',
-			'5.8-beta1-51132-src',
-			'5.8-RC1-src',
-			'5.8-RC1',
-			'5.8-RC1-51270-src',
-			'5.8-src',
-			'5.8',
-			'5.8.1-src',
-			'5.8.1',
-			'5.10-alpha-8675309-src',
-			'5.10-beta1-8675310-src',
-			'5.10-beta1-8675310',
-			'5.10-RC1-8675311',
-			'5.10-src',
-			'5.10',
-		);
-		foreach ( $wp_versions as $wp_version ) {
-			$blocks->init();
-			$this->assertFalse( has_filter( 'block_categories', $callback ), $wp_version );
-			$this->assertNotFalse( has_filter( 'block_categories_all', $callback ), $wp_version );
-			remove_filter( 'block_categories', $callback );
-			remove_filter( 'block_categories_all', $callback );
-		}
 	}
 
 }


### PR DESCRIPTION
Reverts gocodebox/lifterlms-blocks#136 (merged into wrong branch)