### PR TITLE
PHP 8.1 Compat

### DIFF
--- a/includes/class-llms-blocks-reusable.php
+++ b/includes/class-llms-blocks-reusable.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_Blocks/Classes
  *
  * @since 2.0.0
- * @version 2.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -169,6 +169,7 @@ class LLMS_Blocks_Reusable {
 	 * For any other screen we return `false` because we don't care about it.
 	 *
 	 * @since 2.0.0
+	 * @since [version] Don't pass `null` to `basename()`.
 	 *
 	 * @param string $referer Referring URL for the REST request.
 	 * @return string|boolean Returns the screen name or `false` if we don't care about the screen.
@@ -176,7 +177,8 @@ class LLMS_Blocks_Reusable {
 	private function get_screen_from_referer( $referer ) {
 
 		// Blockified widgets screen.
-		if ( 'widgets.php' === basename( wp_parse_url( $referer, PHP_URL_PATH ) ) ) {
+		$url_path = wp_parse_url( $referer, PHP_URL_PATH );
+		if ( $url_path && 'widgets.php' === basename( $url_path ) ) {
 			return 'widgets';
 		}
 

--- a/includes/class-llms-blocks-visibility.php
+++ b/includes/class-llms-blocks-visibility.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_Blocks/Classes
  *
  * @since 1.0.0
- * @version 2.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -215,6 +215,7 @@ class LLMS_Blocks_Visibility {
 	 * WP Core API request.
 	 *
 	 * @since 2.0.0
+	 * @since [version] Don't use deprecated `FILTER_SANITIZE_STRING`.
 	 *
 	 * @link https://developer.wordpress.org/rest-api/reference/rendered-blocks/
 	 *
@@ -228,8 +229,8 @@ class LLMS_Blocks_Visibility {
 
 		if ( llms_is_rest() ) {
 
-			$context = llms_filter_input( INPUT_GET, 'context', FILTER_SANITIZE_STRING );
-			$post_id = llms_filter_input( INPUT_GET, 'post_id', FILTER_SANITIZE_STRING );
+			$context = llms_filter_input( INPUT_GET, 'context' );
+			$post_id = llms_filter_input( INPUT_GET, 'post_id', FILTER_SANITIZE_NUMBER_INT );
 
 			// Always render blocks when a valid user is requesting the block in the edit context.
 			if ( 'edit' === $context && $post_id && current_user_can( 'edit_post', $post_id ) ) {


### PR DESCRIPTION
## Description

Don't use functionality deprecated in php81

Per https://github.com/gocodebox/lifterlms/issues/1850

## How has this been tested?

+ Existing unit tests
+ Automated tests will continue to fail on 8.1 unless run against the llms core php81 branch: https://github.com/gocodebox/lifterlms/pull/1948

## Screenshots <!-- if applicable -->

## Types of changes

+ PHP 8.1 compat

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

