### PR TITLE
Introduce block to render a LifterLMS template

### DIFF
--- a/includes/blocks/class-llms-blocks-php-template-block.php
+++ b/includes/blocks/class-llms-blocks-php-template-block.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * PHP Template block
+ *
+ * @package LifterLMS_Blocks/Blocks
+ *
+ * @since 1.0.0
+ * @version [version]
+ *
+ * @render_hook llms_php-template_render
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * PHP Template block class.
+ *
+ * @since [version]
+ */
+class LLMS_Blocks_PHP_Template_Block extends LLMS_Blocks_Abstract_Block {
+
+	/**
+	 * Block ID.
+	 *
+	 * @var string
+	 */
+	protected $id = 'php-template';
+
+	/**
+	 * Is block dynamic (rendered in PHP).
+	 *
+	 * @var bool
+	 */
+	protected $is_dynamic = true;
+
+	/**
+	 * Templates map, where the keys are the template attribute value and the values are the php file names (w/o extension).
+	 *
+	 * @var array
+	 */
+	protected $templates = array(
+		'archive-course'             => 'loop-main',
+		'archive-llms_membership'    => 'loop-main',
+		'taxonomy-course_cat'        => 'loop-main',
+		'taxonomy-course_difficulty' => 'loop-main',
+		'taxonomy-course_tag'        => 'loop-main',
+		'taxonomy-course_track'      => 'loop-main',
+		'taxonomy-membership_cat'    => 'loop-main',
+		'taxonomy-membership_tag'    => 'loop-main',
+		'single-certificate'         => 'content-certificate',
+		'single-no-access'           => 'content-no-access',
+	);
+
+	/**
+	 * Add actions attached to the render function action.
+	 *
+	 * @since [version]
+	 *
+	 * @param array  $attributes Optional. Block attributes. Default empty array.
+	 * @param string $content    Optional. Block content. Default empty string.
+	 * @return void
+	 */
+	public function add_hooks( $attributes = array(), $content = '' ) {
+
+		add_action( $this->get_render_hook(), array( $this, 'output' ), 10 );
+
+	}
+
+	/**
+	 * Retrieve custom block attributes.
+	 *
+	 * Necessary to override when creating ServerSideRender blocks.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	public function get_attributes() {
+		return array(
+			'template' =>  array(
+				'type'    => 'string',
+				'default' => '',
+			),
+			'title' =>  array(
+				'type'    => 'string',
+				'default' => '',
+			),
+		);
+	}
+
+	/**
+	 * Output the template.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $attributes Optional. Block attributes. Default empty array.
+	 * @return void
+	 */
+	public function output( $attributes = array() ) {
+
+		if ( empty( $attributes['template'] ) ) {
+			return;
+		}
+
+		/**
+		 * Filters the php templates that can be render via this block.
+		 *
+		 * @since [version]
+		 *
+		 * @param array $templates Templates map, where the keys are the template attribute value and the values are the php file names (w/o extension).
+		 */
+		$templates = apply_filters( 'llms_blocks_php_templates_block', $this->templates );
+
+		if ( ! array_key_exists( $attributes['template'], $templates ) ) {
+			return;
+		}
+
+		ob_start();
+
+		llms_get_template( "{$templates[$attributes['template']]}.php" );
+
+		$block_content = ob_get_clean();
+
+		/**
+		 * Filters the block html
+		 *
+		 * @since [version]
+		 *
+		 * @param string                          $block_content The block's html.
+		 * @param array                           $attributes    The block's array of attributes.
+		 * @param LLMS_Blocks_Pricing_Table_Block $block         This block object.
+		 */
+		$block_content = apply_filters( 'llms_blocks_render_php_template_block', $block_content, $attributes, $this );
+
+
+		if ( $block_content ) {
+			echo $block_content;
+		}
+
+	}
+
+}
+
+return new LLMS_Blocks_PHP_Template_Block();

--- a/includes/blocks/class-llms-blocks-php-template-block.php
+++ b/includes/blocks/class-llms-blocks-php-template-block.php
@@ -81,7 +81,7 @@ class LLMS_Blocks_PHP_Template_Block extends LLMS_Blocks_Abstract_Block {
 				'type'    => 'string',
 				'default' => '',
 			),
-			'title' =>  array(
+			'title'    =>  array(
 				'type'    => 'string',
 				'default' => '',
 			),
@@ -131,7 +131,6 @@ class LLMS_Blocks_PHP_Template_Block extends LLMS_Blocks_Abstract_Block {
 		 * @param LLMS_Blocks_Pricing_Table_Block $block         This block object.
 		 */
 		$block_content = apply_filters( 'llms_blocks_render_php_template_block', $block_content, $attributes, $this );
-
 
 		if ( $block_content ) {
 			echo $block_content;

--- a/includes/class-llms-blocks-assets.php
+++ b/includes/class-llms-blocks-assets.php
@@ -7,7 +7,7 @@
  * @package LifterLMS_Blocks/Main
  *
  * @since 1.0.0
- * @version 2.2.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -138,13 +138,14 @@ class LLMS_Blocks_Assets {
 	 * @since 1.10.0 Use `LLMS_Assets` class methods for asset enqueues.
 	 * @since 2.0.0 Maybe load backwards compatibility script.
 	 * @since 2.2.0 Only load assets on post screens.
+	 * @since [version] Also load assets on site editor screen.
 	 *
 	 * @return void
 	 */
 	public function editor_assets() {
 
 		$screen = get_current_screen();
-		if ( $screen && 'post' !== $screen->base ) {
+		if ( $screen && ! in_array( $screen->base, array( 'post', 'site-editor' ), true ) ) {
 			return;
 		}
 

--- a/includes/class-llms-blocks.php
+++ b/includes/class-llms-blocks.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Plugin Initialization.
+ * Plugin Initialization
  *
  * @package LifterLMS_Blocks/Classes
  *
  * @since 1.0.0
- * @version 2.2.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -70,7 +70,7 @@ class LLMS_Blocks {
 
 
 	/**
-	 * Print dynamic block information as a JS variable
+	 * Print dynamic block information as a JS variable.
 	 *
 	 * Allows us to ensure we only add visibility attributes to static blocks.
 	 * Prevents an issue causing rest api validation issues during attribute validation
@@ -112,9 +112,10 @@ class LLMS_Blocks {
 	}
 
 	/**
-	 * Include all files
+	 * Include all files.
 	 *
 	 * @since 2.0.0
+	 * @since [version] Include php template block file.
 	 *
 	 * @return void
 	 */
@@ -145,6 +146,7 @@ class LLMS_Blocks {
 		require_once LLMS_BLOCKS_PLUGIN_DIR . '/includes/blocks/class-llms-blocks-lesson-navigation-block.php';
 		require_once LLMS_BLOCKS_PLUGIN_DIR . '/includes/blocks/class-llms-blocks-lesson-progression-block.php';
 		require_once LLMS_BLOCKS_PLUGIN_DIR . '/includes/blocks/class-llms-blocks-pricing-table-block.php';
+		require_once LLMS_BLOCKS_PLUGIN_DIR . '/includes/blocks/class-llms-blocks-php-template-block.php';
 
 	}
 

--- a/src/js/block-visibility/check.js
+++ b/src/js/block-visibility/check.js
@@ -2,7 +2,7 @@
  * Block-level visibility checks
  *
  * @since 1.6.0
- * @version 2.0.0
+ * @version [version]
  */
 
 // WP Deps.
@@ -12,6 +12,7 @@ import { applyFilters } from '@wordpress/hooks';
  * Returns a list of blocks that we've decided should not support block visibility
  *
  * @since 2.0.0
+ * @since [version] Disallow block visibility for LifterLMS PHP Template block.
  *
  * @return {Array} List of block names.
  */
@@ -30,6 +31,7 @@ const getDisallowedBlocks = () => {
 		 * @see {@link https://github.com/gocodebox/lifterlms-blocks/issues/41}
 		 */
 		'core/freeform',
+		'llms/php-template',
 	] );
 };
 

--- a/src/js/blocks/index.js
+++ b/src/js/blocks/index.js
@@ -2,8 +2,7 @@
  * LifterLMS Block Library.
  *
  * @since 1.7.0
- * @version 2.0.0
- */
+ * @version [version]
 
 /* eslint camelcase: [ "error", { allow: [ "_llms_form_location" ] } ] */
 
@@ -29,6 +28,7 @@ import * as instructors from './instructors/';
 import * as lessonNavigation from './lesson-navigation/';
 import * as lessonProgression from './lesson-progression/';
 import * as pricingTable from './pricing-table/';
+import * as phpTemplate from './php-template/';
 
 // Form Field Blocks.
 import * as formFields from './form-fields/';
@@ -116,6 +116,7 @@ export const deregisterBlocksForForms = () => {
  * @since 1.6.0 Add form field blocks.
  * @since 1.7.3 Move form ready event from domReady to here to ensure blocks are exposed before blocks are parsed.
  * @since 2.0.0 Trigger `llms_form_fields_ready` on `wp_block` posts.
+ * @since [version] Register phpTemplate block.
  */
 export default () => {
 	const postType = getCurrentPostType();
@@ -130,6 +131,7 @@ export default () => {
 		lessonNavigation,
 		lessonProgression,
 		pricingTable,
+		phpTemplate,
 	];
 
 	// Add "composed" form fields to the block registration list.

--- a/src/js/blocks/php-template/index.js
+++ b/src/js/blocks/php-template/index.js
@@ -1,0 +1,114 @@
+/**
+ * BLOCK: llms/php-template
+ *
+ * @since [version]
+ */
+
+// WP deps.
+import { __, sprintf } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+import { Placeholder } from '@wordpress/components';
+
+/**
+ * Block Name.
+ *
+ * @type {String}
+ */
+export const name = 'llms/php-template';
+
+/**
+ * Register Block.
+ *
+ * @since [version]
+ *
+ * @param {string} name     Block name.
+ * @param {Object} settings Block settings.
+ * @return {Object} Block settings object.
+ */
+export const settings = {
+	title: __( 'LifterLMS PHP Template', 'lifterlms' ),
+	category: 'llms-blocks', // common, formatting, layout widgets, embed. see https://wordpress.org/gutenberg/handbook/block-api/#category.
+	keywords: [ __( 'LifterLMS', 'lifterlms' ) ],
+	attributes: {
+		template: {
+			type: 'string',
+			default: '',
+		},
+		title: {
+			type: 'string',
+			default: '',
+		},
+	},
+	supports: {
+		html: false,
+		multiple: false,
+		reusable: false,
+		inserter: false,
+	},
+	/**
+	 * The edit function describes the structure of your block in the context of the editor.
+	 *
+	 * This represents what the editor will render when the block is used.
+	 * The "edit" property must be a valid function.
+	 *
+	 * @since [version]
+	 *
+	 * @param {Object} props Block properties.
+	 * @return {Element} Edit component.
+	 */
+	edit: ( props ) => {
+
+		const { attributes } = props;
+		const blockProps = useBlockProps();
+		const title = attributes.title && window.LLMS.l10n.strings.hasOwnProperty(attributes.title) ?
+			window.LLMS.l10n.strings[attributes.title] : ( attributes.title ? attributes.title : attributes.template );
+
+		return (
+			<div { ...blockProps }>
+				<Placeholder
+					label={ title }
+					className="wp-block-liftelrms-php-template__placeholder"
+				>
+					<div className="wp-block-liftelrms-php-template__placeholder-copy">
+						<p className="wp-block-liftelrms-php-template__placeholder-warning">
+							<strong>
+								{ __(
+									'Attention: Do not remove this block!',
+									'lifterlms'
+								) }
+							</strong>{ ' ' }
+							{ __(
+								'Removal will cause unintended effects on your LMS site.',
+								'lifterlms'
+							) }
+						</p>
+						<p>
+							{ sprintf(
+								/* translators: %s is the template title */
+								__(
+									'This is an editor placeholder for the %s. On your site this will be replaced by the relevant template. You can move this placeholder around and add further blocks around it to extend the template.',
+									'lifterlms'
+								),
+								title
+							) }
+						</p>
+					</div>
+			</Placeholder>
+		</div>
+		);
+	},
+
+	/**
+	 * The save function defines the way in which the different attributes should be combined
+	 * into the final markup, which is then serialized by Gutenberg into post_content.
+	 *
+	 * The "save" property must be specified and must be a valid function.
+	 *
+	 * @since [version]
+	 *
+	 * @return {null} Save function disabled for "dynamic" block.
+	 */
+	save: () => {
+		return null;
+	},
+};


### PR DESCRIPTION
## Description
Adds blocks to render a LifterLMS template for FSE compatibility.

## How has this been tested?
manually

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

