### PR TITLE
Php template updates

### DIFF
--- a/includes/blocks/class-llms-blocks-php-template-block.php
+++ b/includes/blocks/class-llms-blocks-php-template-block.php
@@ -77,16 +77,16 @@ class LLMS_Blocks_PHP_Template_Block extends LLMS_Blocks_Abstract_Block {
 	 */
 	public function get_attributes() {
 		return array(
-			'template' =>  array(
+			'template'  => array(
 				'type'    => 'string',
 				'default' => '',
 			),
-			'title'    =>  array(
+			'title'     => array(
 				'type'    => 'string',
 				'default' => '',
 			),
 			'hideTitle' => array(
-				'type' => 'boolean',
+				'type'    => 'boolean',
 				'default' => false,
 			),
 		);

--- a/includes/blocks/class-llms-blocks-php-template-block.php
+++ b/includes/blocks/class-llms-blocks-php-template-block.php
@@ -85,6 +85,10 @@ class LLMS_Blocks_PHP_Template_Block extends LLMS_Blocks_Abstract_Block {
 				'type'    => 'string',
 				'default' => '',
 			),
+			'hideTitle' => array(
+				'type' => 'boolean',
+				'default' => false,
+			),
 		);
 	}
 
@@ -115,6 +119,10 @@ class LLMS_Blocks_PHP_Template_Block extends LLMS_Blocks_Abstract_Block {
 			return;
 		}
 
+		if ( true === $attributes['hideTitle'] ) {
+			add_filter( 'lifterlms_show_page_title', '__return_false' );
+		}
+
 		ob_start();
 
 		llms_get_template( "{$templates[$attributes['template']]}.php" );
@@ -134,6 +142,10 @@ class LLMS_Blocks_PHP_Template_Block extends LLMS_Blocks_Abstract_Block {
 
 		if ( $block_content ) {
 			echo $block_content;
+		}
+
+		if ( true === $attributes['hideTitle'] ) {
+			remove_filter( 'lifterlms_show_page_title', '__return_false' );
 		}
 
 	}

--- a/src/js/blocks/index.js
+++ b/src/js/blocks/index.js
@@ -3,7 +3,7 @@
  *
  * @since 1.7.0
  * @version [version]
-
+ 
 /* eslint camelcase: [ "error", { allow: [ "_llms_form_location" ] } ] */
 
 // WP Deps.

--- a/src/js/blocks/php-template/get-label.js
+++ b/src/js/blocks/php-template/get-label.js
@@ -1,0 +1,20 @@
+import { __ } from '@wordpress/i18n';
+
+export default function( template ) {
+
+	const labels = {
+		'archive-course':             __( 'Course Catalog', 'lifterlms' ),
+		'archive-llms_membership':    __( 'Membership Catalog', 'lifterlms' ),
+		'single-certificate':         __( 'Single Certificate', 'lifterlms' ),
+		'single-no-access':           __( 'Single Requiring Membership', 'lifterlms' ),
+		'taxonomy-course_cat':        __( 'Taxonomy Course Category', 'lifterlms' ),
+		'taxonomy-course_difficulty': __( 'Taxonomy Course Difficulty', 'lifterlms' ),
+		'taxonomy-course_tag':        __( 'Taxonomy Course Tag', 'lifterlms' ),
+		'taxonomy-course_track':      __( 'Taxonomy Course Track', 'lifterlms' ),
+		'taxonomy-memberhsip_cat':    __( 'Taxonomy Membership Category', 'lifterlms' ),
+		'taxonomy-memberhsip_tag':    __( 'Taxonomy Membership Tag', 'lifterlms' ),
+	};
+
+	return labels[ template ] ?? template;
+
+}

--- a/src/js/blocks/php-template/get-label.js
+++ b/src/js/blocks/php-template/get-label.js
@@ -1,20 +1,24 @@
 import { __ } from '@wordpress/i18n';
 
-export default function( template ) {
-
+export default function ( template ) {
 	const labels = {
-		'archive-course':             __( 'Course Catalog', 'lifterlms' ),
-		'archive-llms_membership':    __( 'Membership Catalog', 'lifterlms' ),
-		'single-certificate':         __( 'Single Certificate', 'lifterlms' ),
-		'single-no-access':           __( 'Single Requiring Membership', 'lifterlms' ),
-		'taxonomy-course_cat':        __( 'Taxonomy Course Category', 'lifterlms' ),
-		'taxonomy-course_difficulty': __( 'Taxonomy Course Difficulty', 'lifterlms' ),
-		'taxonomy-course_tag':        __( 'Taxonomy Course Tag', 'lifterlms' ),
-		'taxonomy-course_track':      __( 'Taxonomy Course Track', 'lifterlms' ),
-		'taxonomy-memberhsip_cat':    __( 'Taxonomy Membership Category', 'lifterlms' ),
-		'taxonomy-memberhsip_tag':    __( 'Taxonomy Membership Tag', 'lifterlms' ),
+		'archive-course': __( 'Course Catalog', 'lifterlms' ),
+		'archive-llms_membership': __( 'Membership Catalog', 'lifterlms' ),
+		'single-certificate': __( 'Single Certificate', 'lifterlms' ),
+		'single-no-access': __( 'Single Requiring Membership', 'lifterlms' ),
+		'taxonomy-course_cat': __( 'Taxonomy Course Category', 'lifterlms' ),
+		'taxonomy-course_difficulty': __(
+			'Taxonomy Course Difficulty',
+			'lifterlms'
+		),
+		'taxonomy-course_tag': __( 'Taxonomy Course Tag', 'lifterlms' ),
+		'taxonomy-course_track': __( 'Taxonomy Course Track', 'lifterlms' ),
+		'taxonomy-memberhsip_cat': __(
+			'Taxonomy Membership Category',
+			'lifterlms'
+		),
+		'taxonomy-memberhsip_tag': __( 'Taxonomy Membership Tag', 'lifterlms' ),
 	};
 
 	return labels[ template ] ?? template;
-
 }

--- a/src/js/blocks/php-template/index.js
+++ b/src/js/blocks/php-template/index.js
@@ -9,6 +9,10 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useBlockProps } from '@wordpress/block-editor';
 import { Placeholder } from '@wordpress/components';
 
+// Internal deps.
+import Inspector from './inspect';
+import getLabel from './get-label';
+
 /**
  * Block Name.
  *
@@ -38,6 +42,10 @@ export const settings = {
 			type: 'string',
 			default: '',
 		},
+		hideTitle: {
+			type: 'boolean',
+			default: false,
+		},
 	},
 	supports: {
 		html: false,
@@ -58,15 +66,16 @@ export const settings = {
 	 */
 	edit: ( props ) => {
 
-		const { attributes } = props;
-		const blockProps = useBlockProps();
-		const title = attributes.title && window.LLMS.l10n.strings.hasOwnProperty(attributes.title) ?
-			window.LLMS.l10n.strings[attributes.title] : ( attributes.title ? attributes.title : attributes.template );
+		const { attributes, setAttributes } = props,
+			{ hideTitle, template } = attributes,
+			blockProps = useBlockProps(),
+			label = getLabel( template );
 
 		return (
 			<div { ...blockProps }>
+				<Inspector { ...{ hideTitle, setAttributes } } />
 				<Placeholder
-					label={ title }
+					label={ label }
 					className="wp-block-liftelrms-php-template__placeholder"
 				>
 					<div className="wp-block-liftelrms-php-template__placeholder-copy">
@@ -89,7 +98,7 @@ export const settings = {
 									'This is an editor placeholder for the %s. On your site this will be replaced by the relevant template. You can move this placeholder around and add further blocks around it to extend the template.',
 									'lifterlms'
 								),
-								title
+								label
 							) }
 						</p>
 					</div>

--- a/src/js/blocks/php-template/index.js
+++ b/src/js/blocks/php-template/index.js
@@ -16,7 +16,7 @@ import getLabel from './get-label';
 /**
  * Block Name.
  *
- * @type {String}
+ * @type {string}
  */
 export const name = 'llms/php-template';
 
@@ -65,7 +65,6 @@ export const settings = {
 	 * @return {Element} Edit component.
 	 */
 	edit: ( props ) => {
-
 		const { attributes, setAttributes } = props,
 			{ hideTitle, template } = attributes,
 			blockProps = useBlockProps(),
@@ -102,8 +101,8 @@ export const settings = {
 							) }
 						</p>
 					</div>
-			</Placeholder>
-		</div>
+				</Placeholder>
+			</div>
 		);
 	},
 

--- a/src/js/blocks/php-template/inspect.js
+++ b/src/js/blocks/php-template/inspect.js
@@ -1,0 +1,41 @@
+// WP Dependencies.
+import { __ } from '@wordpress/i18n';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+
+/**
+ * Block inspector component.
+ *
+ * @since [version]
+ *
+ * @param {Object}   props               Component properties.
+ * @param {Boolean}  props.hideTitle     Current state of the hide title block attribute.
+ * @param {Function} props.setAttributes Function used to update the block's attributes.
+ * @return {InspectorControls} The inspector component.
+ */
+export default function( { hideTitle, setAttributes } ) {
+
+	return (
+		<InspectorControls>
+
+			<PanelBody>
+
+				<ToggleControl
+					label={ __( 'Hide page title', 'lifterlms' ) }
+					checked={ !! hideTitle }
+					onChange={ () =>
+						setAttributes( { hideTitle: ! hideTitle } )
+					}
+					help={
+						!! hideTitle
+							? __( 'Displaying the default title', 'lifterlms' )
+							: __( 'Hiding the default title', 'lifterlms' )
+					}
+				/>
+
+			</PanelBody>
+
+		</InspectorControls>
+	);
+
+}

--- a/src/js/blocks/php-template/inspect.js
+++ b/src/js/blocks/php-template/inspect.js
@@ -9,17 +9,14 @@ import { PanelBody, ToggleControl } from '@wordpress/components';
  * @since [version]
  *
  * @param {Object}   props               Component properties.
- * @param {Boolean}  props.hideTitle     Current state of the hide title block attribute.
+ * @param {boolean}  props.hideTitle     Current state of the hide title block attribute.
  * @param {Function} props.setAttributes Function used to update the block's attributes.
  * @return {InspectorControls} The inspector component.
  */
-export default function( { hideTitle, setAttributes } ) {
-
+export default function ( { hideTitle, setAttributes } ) {
 	return (
 		<InspectorControls>
-
 			<PanelBody>
-
 				<ToggleControl
 					label={ __( 'Hide page title', 'lifterlms' ) }
 					checked={ !! hideTitle }
@@ -32,10 +29,7 @@ export default function( { hideTitle, setAttributes } ) {
 							: __( 'Hiding the default title', 'lifterlms' )
 					}
 				/>
-
 			</PanelBody>
-
 		</InspectorControls>
 	);
-
 }


### PR DESCRIPTION
## Description

Update to #146 

+ Applies block title translations using `@wordpress/i18n`
+ Adds a block option to hide the default page title
+ Fixes CS identifiend by phpcs and eslint

## How has this been tested?

+ Manually

## Screenshots <!-- if applicable -->

## Types of changes

Update

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

