### PR TITLE
Add control for the checkout's form title for free access plans.

### DIFF
--- a/.changelogs/checkout-form-title-free-ap.yml
+++ b/.changelogs/checkout-form-title-free-ap.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: Added an option to specify a custom checkout form title for free access plans.

--- a/src/js/sidebar/form-document-settings/index.js
+++ b/src/js/sidebar/form-document-settings/index.js
@@ -198,7 +198,7 @@ class FormDocumentSettings extends Component {
 										} )
 									}
 								/>
-								{ 'checkout' === location &&
+								{ 'checkout' === location && 'yes' === showTitle &&
 								<TextControl
 									label={ __( 'Free Access Plan Form Title', 'lifterlms' ) }
 									value={ freeApTitle }

--- a/src/js/sidebar/form-document-settings/index.js
+++ b/src/js/sidebar/form-document-settings/index.js
@@ -206,7 +206,7 @@ class FormDocumentSettings extends Component {
 										setFormMetas( { _llms_form_title_free_access_plans: value } )
 									}
 									help={ __(
-										"The form title to be shown for free access plans. Leave it empty if you don't want to show any title for free acces plan checkout forms.",
+										"The form title to be shown for free access plans.",
 										'lifterlms'
 									) }
 								/>

--- a/src/js/sidebar/form-document-settings/index.js
+++ b/src/js/sidebar/form-document-settings/index.js
@@ -4,7 +4,7 @@
  * Displays only on `llms_form` post types.
  *
  * @since 1.6.0
- * @version 2.0.0
+ * @version [version]
  */
 
 // WP Deps.
@@ -14,6 +14,7 @@ import {
 	ExternalLink,
 	PanelRow,
 	ToggleControl,
+	TextControl,
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { dispatch, select, withDispatch, withSelect } from '@wordpress/data';
@@ -44,6 +45,7 @@ class FormDocumentSettings extends Component {
 	 * @since 1.12.0 Add a class name to the document sidebar.
 	 *               Add default template restoration.
 	 * @since 2.0.0 Use default template from location definition in favor of from metadata.
+	 * @since [version] Add control for the checkout's form title for free access plans.
 	 *
 	 * @return {?Fragment} Component HTML fragment or null when not supported.
 	 */
@@ -57,11 +59,11 @@ class FormDocumentSettings extends Component {
 			return null;
 		}
 
-		const { location, link, showTitle, setFormMetas } = this.props,
+		const { location, link, showTitle, freeApTitle, setFormMetas } = this.props,
 			{ formLocations } = window.llms,
 			currentLoc = formLocations[ location ];
 
-		// Set default value.
+		// Set default values.
 		if ( '' === showTitle ) {
 			setFormMetas( { _llms_form_show_title: 'yes' } );
 		}
@@ -196,6 +198,19 @@ class FormDocumentSettings extends Component {
 										} )
 									}
 								/>
+								{ 'checkout' === location &&
+								<TextControl
+									label={ __( 'Free Access Plan Form Title', 'lifterlms' ) }
+									value={ freeApTitle }
+									onChange={ ( value ) =>
+										setFormMetas( { _llms_form_title_free_access_plans: value } )
+									}
+									help={ __(
+										"The form title to be shown for free access plans. Leave it empty if you don't want to show any title for free acces plan checkout forms.",
+										'lifterlms'
+									) }
+								/>
+								}
 								<br />
 								<PanelRow>
 									<Button
@@ -233,6 +248,7 @@ class FormDocumentSettings extends Component {
  * @since 1.7.2 Only modify select when working with an `llms_form` post type.
  * @since 1.12.0 Load the default template meta field.
  * @since 2.0.0 Don't load default template from metadata.
+ * @since [version] Retrieve form title for free access plans meta field.
  */
 const applyWithSelect = withSelect( ( select ) => {
 	const {
@@ -251,6 +267,7 @@ const applyWithSelect = withSelect( ( select ) => {
 		link: getCurrentPost().link,
 		location: meta._llms_form_location,
 		showTitle: meta._llms_form_show_title,
+		freeApTitle: meta._llms_form_title_free_access_plans,
 	};
 } );
 

--- a/src/js/sidebar/form-document-settings/index.js
+++ b/src/js/sidebar/form-document-settings/index.js
@@ -59,8 +59,14 @@ class FormDocumentSettings extends Component {
 			return null;
 		}
 
-		const { location, link, showTitle, freeApTitle, setFormMetas } = this.props,
-			{ formLocations } = window.llms,
+		const {
+			location,
+			link,
+			showTitle,
+			freeApTitle,
+			setFormMetas,
+		} = this.props;
+		const { formLocations } = window.llms,
 			currentLoc = formLocations[ location ];
 
 		// Set default values.
@@ -198,19 +204,25 @@ class FormDocumentSettings extends Component {
 										} )
 									}
 								/>
-								{ 'checkout' === location && 'yes' === showTitle &&
-								<TextControl
-									label={ __( 'Free Access Plan Form Title', 'lifterlms' ) }
-									value={ freeApTitle }
-									onChange={ ( value ) =>
-										setFormMetas( { _llms_form_title_free_access_plans: value } )
-									}
-									help={ __(
-										"The form title to be shown for free access plans.",
-										'lifterlms'
+								{ 'checkout' === location &&
+									'yes' === showTitle && (
+										<TextControl
+											label={ __(
+												'Free Access Plan Form Title',
+												'lifterlms'
+											) }
+											value={ freeApTitle }
+											onChange={ ( val ) =>
+												setFormMetas( {
+													_llms_form_title_free_access_plans: val,
+												} )
+											}
+											help={ __(
+												'The form title to be shown for free access plans.',
+												'lifterlms'
+											) }
+										/>
 									) }
-								/>
-								}
 								<br />
 								<PanelRow>
 									<Button


### PR DESCRIPTION
## Description
per https://github.com/gocodebox/lifterlms/issues/1774

requires https://github.com/gocodebox/lifterlms/pull/2010

## How has this been tested?
manually

## Screenshots <!-- if applicable -->
![Schermata 2022-02-22 alle 15 13 58](https://user-images.githubusercontent.com/7689242/155157324-89a31699-eeb5-4cf8-aee1-842ee17c1a7d.png)

~That control only shows in checkout forms, and it's decoupled from the display form title toggle, which only acts on the main form title. I thought to decouple them so that users can:~
~1) show a title in a non-free access plan, but not on a free access plan (by clearing the specific option text control)~
~2) show a title in a non-free access plan and on a free access plan~
~3) not show a title in a non-free access plan but show it on a free access plan~

see
https://github.com/gocodebox/lifterlms/pull/2010#discussion_r812090304

## Types of changes
Bug fix (non-breaking change which fixes an issue)/New feature (non-breaking change which adds functionality) 

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

