### PR TITLE
Fixed access to non-existing variable when current user tries to edit course/membership instructors without proper permissions

### DIFF
--- a/.changelogs/intructors-update-fix-error.yml
+++ b/.changelogs/intructors-update-fix-error.yml
@@ -1,0 +1,5 @@
+significance: minor
+type: fixed
+links:
+- "#140"
+entry: Fixed access to non-existing variable when current user tries to edit course/membership instructors without proper permissions.

--- a/includes/class-llms-blocks-post-instructors.php
+++ b/includes/class-llms-blocks-post-instructors.php
@@ -5,7 +5,7 @@
  * @package  LifterLMS_Blocks/Classes
  *
  * @since 1.0.0
- * @version 1.7.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -122,11 +122,12 @@ class LLMS_Blocks_Post_Instructors {
 	 *
 	 * @since 1.0.0
 	 * @since 1.7.1 Decode JSON prior to saving.
+	 * @since [version] Fix access to non-existing variable when current user canno edit the course/membership.
 	 *
-	 * @param   string  $value  Instructor data to add to the object (JSON).
-	 * @param   WP_Post $object WP_Post object.
-	 * @param   string  $key    name of the field.
-	 * @return  null|WP_Error
+	 * @param string  $value  Instructor data to add to the object (JSON).
+	 * @param WP_Post $object WP_Post object.
+	 * @param string  $key    Name of the field.
+	 * @return null|WP_Error
 	 */
 	public function update_callback( $value, $object, $key ) {
 
@@ -135,7 +136,7 @@ class LLMS_Blocks_Post_Instructors {
 				'rest_cannot_update',
 				__( 'Sorry, you are not allowed to edit the object instructors.', 'lifterlms' ),
 				array(
-					'key'    => $name,
+					'key'    => $key,
 					'status' => rest_authorization_required_code(),
 				)
 			);

--- a/tests/phpunit/unit-tests/class-llms-blocks-test-post-instructors.php
+++ b/tests/phpunit/unit-tests/class-llms-blocks-test-post-instructors.php
@@ -7,7 +7,8 @@
  * @group post_instructors
  *
  * @since 1.6.0
- * @version 1.6.0
+ * @since [version] Added tests on `update_callback()` method for users without permissions to set course/membership instructors.
+ * @version [version]
  */
 class LLMS_Blocks_Test_Post_Instructors extends LLMS_Blocks_Unit_Test_Case {
 
@@ -141,4 +142,27 @@ class LLMS_Blocks_Test_Post_Instructors extends LLMS_Blocks_Unit_Test_Case {
 
 	}
 
+	/**
+	 * Test update_callback method whith a user who has no permissions to set instructors.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_update_callback_no_permission() {
+
+		foreach ( array( 'course', 'llms_membership' ) as $post_type ) {
+
+			$obj = llms_get_post( $this->factory->post->create( array(
+				'post_type' => $post_type,
+			) ) );
+
+			$res = $this->instance->update_callback( array(), $obj, 'instructors' );
+			$this->assertWPError( $res );
+			$this->assertWPErrorCodeEquals( 'rest_cannot_update', $res );
+			$this->assertSame( 'Sorry, you are not allowed to edit the object instructors.', $res->get_error_message() );
+			$this->assertEquals( array( 'key' => 'instructors', 'status' => 401 ), $res->get_error_data(), $post_type );
+
+		}
+	}
 }


### PR DESCRIPTION
## Description

Fixes #140 
(was reorganizing the issues assigned to me and found this low hanging fruit)

## How has this been tested?
unit tests

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

