### PR TITLE
Preserve global components from other sources

### DIFF
--- a/.changelogs/component-extensibility.yml
+++ b/.changelogs/component-extensibility.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: changed
+entry: Components added to `window.llms.components` are now aware of components
+  added to the object from other sources.

--- a/src/js/blocks.js
+++ b/src/js/blocks.js
@@ -2,7 +2,7 @@
  * Main Block editor entry point.
  *
  * @since 1.0.0
- * @version 2.0.0
+ * @version [version]
  */
 
 // SCSS.
@@ -20,8 +20,12 @@ import './data/';
 import registerBlocks from './blocks/';
 registerBlocks();
 
+// Preserve components from `@lifterlms/components`.
+const { components = {} } = window.llms;
+
 // Import core Components and expose them for 3rd parties to utilize.
 import * as Components from './components/';
 window.llms.components = {
+	...components,
 	...Components,
 };


### PR DESCRIPTION
## Description

LifterLMS 6.0 introduces a react component library, accessible via the `llms-components` WP script dependency. When loaded, the components are added to `window.llms.components`. See: https://github.com/gocodebox/lifterlms/tree/dev-600/packages/components

Since LifterLMS blocks already adds it's own component library to the same object this PR introduces code to make ensure that components from any source are preserved, regardless of script file load order.


## How has this been tested?

+ Manually

## Screenshots <!-- if applicable -->

## Types of changes
+ llms 6.0 compat

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

