### PR TITLE
Fix issue where `user_login` field block is shown to logged-in users

### DIFF
--- a/.changelogs/user-login-default.yml
+++ b/.changelogs/user-login-default.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+links: https://github.com/gocodebox/lifterlms/issues/2071
+entry: Fixed issue where the `user_login` field block was shown to logged-in users.

--- a/.changelogs/user-login-default.yml
+++ b/.changelogs/user-login-default.yml
@@ -1,4 +1,5 @@
 significance: patch
 type: fixed
-links: https://github.com/gocodebox/lifterlms/issues/2071
+links: 
+  - gocodebox/lifterlms#2071
 entry: Fixed issue where the `user_login` field block was shown to logged-in users.

--- a/includes/class-llms-blocks-visibility.php
+++ b/includes/class-llms-blocks-visibility.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_Blocks/Classes
  *
  * @since 1.0.0
- * @version 2.3.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -114,6 +114,7 @@ class LLMS_Blocks_Visibility {
 	 * @since 1.0.0
 	 * @since 1.6.0 Add logic for `logged_in` and `logged_out` block visibility options.
 	 * @since 2.0.0 Added a conditional prior to checking the block's visibility attributes.
+	 * @since [version] Set the `user_login` field block's visibility to its default 'logged_out' if not set.
 	 *
 	 * @param string $content Block inner content.
 	 * @param array  $block   Block data array.
@@ -126,7 +127,14 @@ class LLMS_Blocks_Visibility {
 			return $content;
 		}
 
-		// No attributes or no llms visibility settings (visibile to "all").
+		// Set the `user_login` field block's visibility to its default 'logged_out' if not set.
+		// The WordPress serializer `getCommentAttributes()` function removes the attribute before being
+		// serialized into `post_content` if the attribute can have only one value and it's the default.
+		if ( 'llms/form-field-user-login' === $block['blockName'] && empty( $block['attrs']['llms_visibility'] ) ) {
+			$block['attrs']['llms_visibility'] = 'logged_out';
+		}
+
+		// No attributes or no llms visibility settings (visible to "all").
 		if ( empty( $block['attrs'] ) || empty( $block['attrs']['llms_visibility'] ) ) {
 			return $content;
 		}


### PR DESCRIPTION
## Description
Set the `user_login` field block's visibility to its default 'logged_out' if not set.

Fixes https://github.com/gocodebox/lifterlms/issues/2071

## How has this been tested?
Manually and with unit tests.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

