### PR TITLE
Fix issue when editing confirmation fields with WordPress 6.0

### DIFF
--- a/.changelogs/issue_170-1.yml
+++ b/.changelogs/issue_170-1.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#170"
+entry: Fixed an issue that prevented to edit confirmation fields when running
+  WordPress 6.0.

--- a/.changelogs/issue_170-1.yml
+++ b/.changelogs/issue_170-1.yml
@@ -2,5 +2,5 @@ significance: patch
 type: fixed
 links:
   - "#170"
-entry: Fixed an issue that prevented to edit confirmation fields when running
+entry: Fixed an issue that prevented editing form confirmation fields when running
   WordPress 6.0.

--- a/.changelogs/issue_170.yml
+++ b/.changelogs/issue_170.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Fix field columns sizing in the block editor.

--- a/.changelogs/issue_170.yml
+++ b/.changelogs/issue_170.yml
@@ -1,3 +1,3 @@
 significance: patch
 type: fixed
-entry: Fix field columns sizing in the block editor.
+entry: Fixed field columns sizing in the block editor.

--- a/includes/class-llms-blocks-assets.php
+++ b/includes/class-llms-blocks-assets.php
@@ -7,7 +7,7 @@
  * @package LifterLMS_Blocks/Main
  *
  * @since 1.0.0
- * @version 2.3.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -139,6 +139,7 @@ class LLMS_Blocks_Assets {
 	 * @since 2.0.0 Maybe load backwards compatibility script.
 	 * @since 2.2.0 Only load assets on post screens.
 	 * @since 2.3.0 Also load assets on site editor screen.
+	 * @since [version] Added script localization.
 	 *
 	 * @return void
 	 */
@@ -155,6 +156,14 @@ class LLMS_Blocks_Assets {
 
 		$this->assets->enqueue_script( 'llms-blocks-editor' );
 		$this->assets->enqueue_style( 'llms-blocks-editor' );
+
+		wp_localize_script(
+			'llms-blocks-editor',
+			'llmsBlocks',
+			array(
+				'variationIconCanBeObject' => self::can_variation_transform_icon_be_an_object(),
+			)
+		);
 
 	}
 
@@ -184,6 +193,19 @@ class LLMS_Blocks_Assets {
 		);
 	}
 
+	/**
+	 * Can a variation transform icon be an object.
+	 *
+	 * @since [version]
+	 *
+	 * @return boolean
+	 */
+	private static function can_variation_transform_icon_be_an_object() {
+		// https://github.com/gocodebox/lifterlms-blocks/issues/170.
+		global $wp_version;
+		return version_compare( $wp_version, '6.0-src', '<' ) && ! defined( 'GUTENBERG_VERSION' )
+				|| ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '13.0', '<' ) );
+	}
 
 }
 

--- a/includes/class-llms-blocks-assets.php
+++ b/includes/class-llms-blocks-assets.php
@@ -198,10 +198,11 @@ class LLMS_Blocks_Assets {
 	 *
 	 * @since [version]
 	 *
+	 * @link https://github.com/gocodebox/lifterlms-blocks/issues/170
+	 *
 	 * @return boolean
 	 */
 	private static function can_variation_transform_icon_be_an_object() {
-		// https://github.com/gocodebox/lifterlms-blocks/issues/170.
 		global $wp_version;
 		return version_compare( $wp_version, '6.0-src', '<' ) && ! defined( 'GUTENBERG_VERSION' )
 				|| ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '13.0', '<' ) );

--- a/src/js/blocks/form-fields/editor.scss
+++ b/src/js/blocks/form-fields/editor.scss
@@ -2,7 +2,7 @@
 // Editor Styles for Admin Panel
 //
 // @since 1.6.0
-// @version 2.1.0
+// @version [version]
 //
 
 .llms-invalid-control {
@@ -40,8 +40,11 @@
 	}
 }
 
-.llms-fields {
+.llms-field-group .block-editor-block-list__layout * {
+	box-sizing: border-box;
+}
 
+.llms-fields {
 	input,
 	textarea {
 		border: 1px solid #999;

--- a/src/js/blocks/form-fields/fields/text.js
+++ b/src/js/blocks/form-fields/fields/text.js
@@ -113,6 +113,7 @@ const variations = [
  * Add information to each variation
  *
  * @since 2.0.0
+ * @since [version] Temporary skip merging foreground color for certain block editor versions.
  *
  * @param {Object} variation A block variation object.
  * @return {Object[]} Update block variations array.
@@ -121,11 +122,17 @@ variations.forEach( ( variation ) => {
 	// Setup scope.
 	variation.scope = variation.scope || [ 'block', 'inserter', 'transform' ];
 
-	// Update the icon (add the default foreground color.
-	variation.icon = {
-		...baseSettings.icon,
-		src: variation.icon,
-	};
+	/**
+	 * Temporary skip merging foreground color for certain block editor versions.
+	 * See https://github.com/gocodebox/lifterlms-blocks/issues/170
+	 */
+	if ( window.llmsBlocks.variationIconCanBeObject ) {
+		// Update the icon (add the default foreground color.
+		variation.icon = {
+			...baseSettings.icon,
+			src: variation.icon,
+		};
+	}
 
 	// Add a "field" attribute based off the variation name.
 	if ( ! variation.attributes ) {


### PR DESCRIPTION

## Description

Fixes #170 
Also fixes columns box-sizing in the editor (as reported by the same user on slack)

## How has this been tested?
manually:
- with WP 5.9 with and without the Gutenberg plugin (version 13+)
- with WP 6.0 with and without the Gutenberg plugin (version 13+)



## Types of changes

Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

