### PR TITLE
Fixed LifterLMS preset form field duplication

### DIFF
--- a/.changelogs/issue_169.yml
+++ b/.changelogs/issue_169.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#169"
+entry: Fixed an issue when duplicating a LifterLMS preset form field.

--- a/src/js/blocks/form-fields/edit.js
+++ b/src/js/blocks/form-fields/edit.js
@@ -109,7 +109,7 @@ const setupAtts = ( atts, blockAtts, addingField ) => {
  * @since 2.0.0
  * @since 2.0.1 Use non-unique error notice IDs for reusable multiple error notice.
  * @since 2.2.0 Remove reusable multiple error notice.
- * @since [version] Exclude default LifterLMS user fields when computing `addingField` {link https://github.com/gocodebox/lifterlms-blocks/issues/169}.
+ * @since [version] Exclude LifterLMS preset fields when computing `addingField`.
  *
  * @param {Object} props Component properties.
  * @return {Object} HTML component fragment.
@@ -130,7 +130,11 @@ export function EditField( props ) {
 		addingField =
 			attributes.name &&
 			isDuplicate( attributes.name, clientId ) &&
-			// Fixed an issue when duplicating a LifterLMS preset form field.
+			/**
+			 * Allow LifterLMS preset fields to be duplicated without altering their id and name attributes.
+			 *
+			 * @see {@link https://github.com/gocodebox/lifterlms-blocks/issues/169}
+			 */
 			0 !== name.indexOf( 'llms/form-field-user-' ),
 		/**
 		 * Prevent confirmation fields from being copied/pasted into the editor out of their intended context.

--- a/src/js/blocks/form-fields/edit.js
+++ b/src/js/blocks/form-fields/edit.js
@@ -66,7 +66,6 @@ const generateId = ( name ) => {
  * @return {Object} Attribute object suitable for use when registering the block.
  */
 const setupAtts = ( atts, blockAtts, addingField ) => {
-
 	// Merge configured defaults into the block attributes.
 	Object.keys( blockAtts ).forEach( ( key ) => {
 		const defaultValue = blockAtts[ key ].__default;
@@ -129,9 +128,10 @@ export function EditField( props ) {
 		{ isDuplicate } = select( fieldsStore ),
 		inFieldGroup = context[ 'llms/fieldGroup/fieldLayout' ] ? true : false,
 		addingField =
-			attributes.name && isDuplicate( attributes.name, clientId )
-				// Skip default llms user fields.
-				&&  0 !== name.indexOf( 'llms/form-field-user-' ),
+			attributes.name &&
+			isDuplicate( attributes.name, clientId ) &&
+			// Fixed an issue when duplicating a LifterLMS preset form field.
+			0 !== name.indexOf( 'llms/form-field-user-' ),
 		/**
 		 * Prevent confirmation fields from being copied/pasted into the editor out of their intended context.
 		 *

--- a/src/js/blocks/form-fields/edit.js
+++ b/src/js/blocks/form-fields/edit.js
@@ -2,7 +2,7 @@
  * Edit components
  *
  * @since 2.0.0
- * @version 2.2.0
+ * @version [version]
  */
 
 // External deps.
@@ -66,6 +66,7 @@ const generateId = ( name ) => {
  * @return {Object} Attribute object suitable for use when registering the block.
  */
 const setupAtts = ( atts, blockAtts, addingField ) => {
+
 	// Merge configured defaults into the block attributes.
 	Object.keys( blockAtts ).forEach( ( key ) => {
 		const defaultValue = blockAtts[ key ].__default;
@@ -109,6 +110,7 @@ const setupAtts = ( atts, blockAtts, addingField ) => {
  * @since 2.0.0
  * @since 2.0.1 Use non-unique error notice IDs for reusable multiple error notice.
  * @since 2.2.0 Remove reusable multiple error notice.
+ * @since [version] Exclude default LifterLMS user fields when computing `addingField` {link https://github.com/gocodebox/lifterlms-blocks/issues/169}.
  *
  * @param {Object} props Component properties.
  * @return {Object} HTML component fragment.
@@ -127,7 +129,9 @@ export function EditField( props ) {
 		{ isDuplicate } = select( fieldsStore ),
 		inFieldGroup = context[ 'llms/fieldGroup/fieldLayout' ] ? true : false,
 		addingField =
-			attributes.name && isDuplicate( attributes.name, clientId ),
+			attributes.name && isDuplicate( attributes.name, clientId )
+				// Skip default llms user fields.
+				&&  0 !== name.indexOf( 'llms/form-field-user-' ),
 		/**
 		 * Prevent confirmation fields from being copied/pasted into the editor out of their intended context.
 		 *


### PR DESCRIPTION
## Description
Fixes #169 

The idea is to skip the unique_id/name generation for the preset LifterLMS form fields, even if they're duplicates because there's no way (through the UI) for the user to then alter these values. So the fields will be added, id and name will be present twice in the form, they'll get informed, as before, that those fields can only be present once in the form and they will be able to delete them without "breaking" the original ones.

## How has this been tested?
manually, following the reproduction steps in #169

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

