### PR TITLE
Fixed Launch Course Builder buttons not working when WordPress was installed in a subdirectory

### DIFF
--- a/.changelogs/fix-course-builder-button.yml
+++ b/.changelogs/fix-course-builder-button.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+entry: Fixes Launch Course Builder buttons not working when WordPress was
+  installed in a subdirectory.

--- a/src/js/sidebar/course-builder/sidebar-launch-button.jsx
+++ b/src/js/sidebar/course-builder/sidebar-launch-button.jsx
@@ -1,3 +1,10 @@
+/**
+ * Sidebar launch button.
+ *
+ * @since 2.5.0
+ * @version [version]
+ */
+
 import { __ } from '@wordpress/i18n';
 import { select } from '@wordpress/data';
 import { registerPlugin } from '@wordpress/plugins';
@@ -6,6 +13,13 @@ import { Button } from '@wordpress/components';
 
 import './editor.scss';
 
+/**
+ * Sidebar launch button component.
+ *
+ * @since 2.5.0
+ * @since [version] Fix button link using localized admin url so to avoid issues when
+ *               WordPress is installed in a subdirectory.
+ */
 const SidebarLaunchButton = () => {
 	const postType = select( 'core/editor' )?.getCurrentPostType() ?? '';
 
@@ -19,7 +33,7 @@ const SidebarLaunchButton = () => {
 		className={ 'llms-launch-course-builder' }
 	>
 		<Button
-			href={ '/wp-admin/admin.php?page=llms-course-builder&course_id=' + courseId }
+			href={ window.llms.admin_url + 'admin.php?page=llms-course-builder&course_id=' + courseId }
 			className={ 'llms-button-primary' }
 		>
 			{ __( 'Launch Course Builder', 'lifterlms' ) }

--- a/src/js/sidebar/course-builder/toolbar-launch-button.jsx
+++ b/src/js/sidebar/course-builder/toolbar-launch-button.jsx
@@ -1,8 +1,22 @@
+/**
+ * Tooblar launch button.
+ *
+ * @since 2.5.0
+ * @version [version]
+ */
+
 import { select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 const buttonId = 'llms-launch-course-builder-top-button';
 
+/**
+ * Toolbar launch button component.
+ *
+ * @since 2.5.0
+ * @since [version] Fix button link using localized admin url so to avoid issues when
+ *               WordPress is installed in a subdirectory.
+ */
 export const addToolbarLaunchButton = () => {
 	const editPostHeaderToolbarLeft = document.getElementsByClassName(
 		'edit-post-header-toolbar__left'
@@ -24,7 +38,7 @@ export const addToolbarLaunchButton = () => {
 		const button = document.createElement( 'a' );
 
 		button.id = buttonId;
-		button.href = '/wp-admin/admin.php?page=llms-course-builder&course_id=' + courseId;
+		button.href = window.llms.admin_url + 'admin.php?page=llms-course-builder&course_id=' + courseId;
 		button.className = 'llms-button-primary';
 		button.style.marginLeft = '16px';
 		button.innerHTML = __( 'Launch Course Builder', 'lifterlms' );


### PR DESCRIPTION
Fixes https://github.com/gocodebox/lifterlms/issues/2461

