### PR TITLE
Deprecate pricing table, course continue button and course progress blocks

### DIFF
--- a/.changelogs/deprecate-pricing-table-1.yml
+++ b/.changelogs/deprecate-pricing-table-1.yml
@@ -1,0 +1,5 @@
+significance: minor
+type: removed
+links:
+  - "#197"
+entry: Removed Course Continue block (moved to core plugin).

--- a/.changelogs/deprecate-pricing-table-2.yml
+++ b/.changelogs/deprecate-pricing-table-2.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: changed
+entry: Update course continue button HTML in migrate template.

--- a/.changelogs/deprecate-pricing-table.yml
+++ b/.changelogs/deprecate-pricing-table.yml
@@ -1,0 +1,5 @@
+significance: minor
+type: deprecated
+links:
+  - "#197"
+entry: Deprecated course continue button, course progress and pricing table blocks.

--- a/.changelogs/deprecate-pricing-table.yml
+++ b/.changelogs/deprecate-pricing-table.yml
@@ -2,4 +2,4 @@ significance: minor
 type: deprecated
 links:
   - "#197"
-entry: Deprecated course continue button, course progress and pricing table blocks.
+entry: Deprecated `LLMS_Blocks_Course_Progress_Block` and `LLMS_Blocks_Pricing_Table_Block`.

--- a/includes/blocks/class-llms-blocks-course-progress-block.php
+++ b/includes/blocks/class-llms-blocks-course-progress-block.php
@@ -101,4 +101,100 @@ class LLMS_Blocks_Course_Progress_Block extends LLMS_Blocks_Abstract_Block {
 		}
 
 	}
+
+	/**
+	 * Retrieve the ID/Name of the block.
+	 *
+	 * @return  string
+	 * @since   1.0.0
+	 * @version 1.0.0
+	 */
+	public function get_block_id() {
+		llms_deprecated_function( __METHOD__, '[version]' );
+
+		return sprintf( '%1$s/%2$s', $this->vendor, $this->id );
+	}
+
+	/**
+	 * Output a message when no HTML was rendered
+	 *
+	 * @since 1.0.0
+	 * @since 1.8.0 Don't output empty render messages on the frontend.
+	 *
+	 * @return  string
+	 */
+	public function get_empty_render_message() {
+		llms_deprecated_function( __METHOD__, '[version]' );
+
+		if ( ! is_admin() ) {
+			return '';
+		}
+		return __( 'No HTML was returned.', 'lifterlms' );
+	}
+
+	/**
+	 * Retrieve a string which can be used to render the block.
+	 *
+	 * @return  string
+	 * @since   1.0.0
+	 * @version 1.0.0
+	 */
+	public function get_render_hook() {
+		llms_deprecated_function( __METHOD__, '[version]' );
+
+		return sprintf( '%1$s_%2$s_block_render', $this->vendor, $this->id );
+	}
+
+	/**
+	 * Removed hooks stub.
+	 * Extending classes can use this class to remove hooks attached to the render function action.
+	 *
+	 * @return  void
+	 * @since   1.0.0
+	 * @version 1.0.0
+	 */
+	public function remove_hooks() {
+		llms_deprecated_function( __METHOD__, '[version]' );
+	}
+
+	/**
+	 * Renders the block type output for given attributes.
+	 *
+	 * @param   array  $attributes Optional. Block attributes. Default empty array.
+	 * @param   string $content    Optional. Block content. Default empty string.
+	 * @return  string
+	 * @since   1.0.0
+	 * @version 1.0.0
+	 */
+	public function render_callback( $attributes = array(), $content = '' ) {
+		llms_deprecated_function( __METHOD__, '[version]' );
+
+		$this->add_hooks( $attributes, $content );
+
+		ob_start();
+		do_action( $this->get_render_hook(), $attributes, $content );
+		$ret = ob_get_clean();
+
+		$this->remove_hooks();
+
+		if ( ! $ret ) {
+			$ret = $this->get_empty_render_message();
+		}
+
+		return $ret;
+
+	}
+
+	/**
+	 * Register meta attributes stub.
+	 *
+	 * Called after registering the block type.
+	 *
+	 * @return  void
+	 * @since   1.0.0
+	 * @version 1.0.0
+	 */
+	public function register_meta() {
+		llms_deprecated_function( __METHOD__, '[version]' );
+	}
 }

--- a/includes/blocks/class-llms-blocks-course-progress-block.php
+++ b/includes/blocks/class-llms-blocks-course-progress-block.php
@@ -6,6 +6,7 @@
  *
  * @since 1.9.0
  * @version 1.9.0
+ * @deprecated [version]
  *
  * @render_hook llms_course-progress_block_render
  */
@@ -14,6 +15,9 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Course progress block class.
+ *
+ * @since Unknown
+ * @deprecated [version]
  */
 class LLMS_Blocks_Course_Progress_Block extends LLMS_Blocks_Abstract_Block {
 
@@ -35,12 +39,14 @@ class LLMS_Blocks_Course_Progress_Block extends LLMS_Blocks_Abstract_Block {
 	 * Add actions attached to the render function action.
 	 *
 	 * @since 1.9.0
+	 * @deprecated [version]
 	 *
 	 * @param array  $attributes Optional. Block attributes. Default empty array.
 	 * @param string $content    Optional. Block content. Default empty string.
 	 * @return void
 	 */
 	public function add_hooks( $attributes = array(), $content = '' ) {
+		llms_deprecated_function( __METHOD__, '[version]' );
 
 		add_action( $this->get_render_hook(), array( $this, 'output' ), 10 );
 
@@ -50,11 +56,13 @@ class LLMS_Blocks_Course_Progress_Block extends LLMS_Blocks_Abstract_Block {
 	 * Output the course progress bar
 	 *
 	 * @since 1.9.0
+	 * @deprecated [version]
 	 *
 	 * @param array $attributes Optional. Block attributes. Default empty array.
 	 * @return void
 	 */
 	public function output( $attributes = array() ) {
+		llms_deprecated_function( __METHOD__, '[version]' );
 
 		$block_content = '';
 		$progress      = do_shortcode( '[lifterlms_course_progress check_enrollment=1]' );
@@ -75,12 +83,18 @@ class LLMS_Blocks_Course_Progress_Block extends LLMS_Blocks_Abstract_Block {
 		 * Filters the block html
 		 *
 		 * @since 1.9.0
+		 * @deprecated [version]
 		 *
-		 * @param string                            $block_content The block's html.
-		 * @param array                             $attributes    The block's array of attributes.
-		 * @param LLMS_Blocks_Course_Progress_Block $block         This block object.
+		 * @param string $block_content The block's html.
+		 * @param array  $attributes    The block's array of attributes.
+		 * @param self   $block         This block object.
 		 */
-		$block_content = apply_filters( 'llms_blocks_render_course_progress_block', $block_content, $attributes, $this );
+		$block_content = apply_filters_deprecated(
+			'llms_blocks_render_course_progress_block',
+			array( $block_content, $attributes, $this ),
+			'[version]',
+			'render_block_llms/course-progress'
+		);
 
 		if ( $block_content ) {
 			echo $block_content;
@@ -88,5 +102,3 @@ class LLMS_Blocks_Course_Progress_Block extends LLMS_Blocks_Abstract_Block {
 
 	}
 }
-
-return new LLMS_Blocks_Course_Progress_Block();

--- a/includes/blocks/class-llms-blocks-pricing-table-block.php
+++ b/includes/blocks/class-llms-blocks-pricing-table-block.php
@@ -139,4 +139,100 @@ class LLMS_Blocks_Pricing_Table_Block extends LLMS_Blocks_Abstract_Block {
 		}
 
 	}
+
+	/**
+	 * Retrieve the ID/Name of the block.
+	 *
+	 * @return  string
+	 * @since   1.0.0
+	 * @version 1.0.0
+	 */
+	public function get_block_id() {
+		llms_deprecated_function( __METHOD__, '[version]' );
+
+		return sprintf( '%1$s/%2$s', $this->vendor, $this->id );
+	}
+
+	/**
+	 * Output a message when no HTML was rendered
+	 *
+	 * @since 1.0.0
+	 * @since 1.8.0 Don't output empty render messages on the frontend.
+	 *
+	 * @return  string
+	 */
+	public function get_empty_render_message() {
+		llms_deprecated_function( __METHOD__, '[version]' );
+
+		if ( ! is_admin() ) {
+			return '';
+		}
+		return __( 'No HTML was returned.', 'lifterlms' );
+	}
+
+	/**
+	 * Retrieve a string which can be used to render the block.
+	 *
+	 * @return  string
+	 * @since   1.0.0
+	 * @version 1.0.0
+	 */
+	public function get_render_hook() {
+		llms_deprecated_function( __METHOD__, '[version]' );
+
+		return sprintf( '%1$s_%2$s_block_render', $this->vendor, $this->id );
+	}
+
+	/**
+	 * Removed hooks stub.
+	 * Extending classes can use this class to remove hooks attached to the render function action.
+	 *
+	 * @return  void
+	 * @since   1.0.0
+	 * @version 1.0.0
+	 */
+	public function remove_hooks() {
+		llms_deprecated_function( __METHOD__, '[version]' );
+	}
+
+	/**
+	 * Renders the block type output for given attributes.
+	 *
+	 * @param   array  $attributes Optional. Block attributes. Default empty array.
+	 * @param   string $content    Optional. Block content. Default empty string.
+	 * @return  string
+	 * @since   1.0.0
+	 * @version 1.0.0
+	 */
+	public function render_callback( $attributes = array(), $content = '' ) {
+		llms_deprecated_function( __METHOD__, '[version]' );
+
+		$this->add_hooks( $attributes, $content );
+
+		ob_start();
+		do_action( $this->get_render_hook(), $attributes, $content );
+		$ret = ob_get_clean();
+
+		$this->remove_hooks();
+
+		if ( ! $ret ) {
+			$ret = $this->get_empty_render_message();
+		}
+
+		return $ret;
+
+	}
+
+	/**
+	 * Register meta attributes stub.
+	 *
+	 * Called after registering the block type.
+	 *
+	 * @return  void
+	 * @since   1.0.0
+	 * @version 1.0.0
+	 */
+	public function register_meta() {
+		llms_deprecated_function( __METHOD__, '[version]' );
+	}
 }

--- a/includes/blocks/class-llms-blocks-pricing-table-block.php
+++ b/includes/blocks/class-llms-blocks-pricing-table-block.php
@@ -6,6 +6,7 @@
  *
  * @since 1.0.0
  * @version 1.9.0
+ * @deprecated [version]
  *
  * @render_hook llms_pricing-table-block_render
  */
@@ -13,11 +14,12 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Course syllabus block class
+ * Pricing Table block class.
  *
  * @since 1.0.0
  * @since 1.3.7 Unknown.
  * @since 1.9.0 Added `llms_blocks_render_pricing_table_block` filter.
+ * @deprecated [version]
  */
 class LLMS_Blocks_Pricing_Table_Block extends LLMS_Blocks_Abstract_Block {
 
@@ -40,12 +42,14 @@ class LLMS_Blocks_Pricing_Table_Block extends LLMS_Blocks_Abstract_Block {
 	 *
 	 * @since 1.0.0
 	 * @since 1.1.0 Unknown.
+	 * @deprecated [version]
 	 *
 	 * @param array  $attributes Optional. Block attributes. Default empty array.
 	 * @param string $content    Optional. Block content. Default empty string.
 	 * @return void
 	 */
 	public function add_hooks( $attributes = array(), $content = '' ) {
+		llms_deprecated_function( __METHOD__, '[version]' );
 
 		add_action( $this->get_render_hook(), array( $this, 'output' ), 10 );
 
@@ -58,10 +62,13 @@ class LLMS_Blocks_Pricing_Table_Block extends LLMS_Blocks_Abstract_Block {
 	 *
 	 * @since 1.0.0
 	 * @since 1.3.6 Unknown.
+	 * @deprecated [version]
 	 *
 	 * @return array
 	 */
 	public function get_attributes() {
+		llms_deprecated_function( __METHOD__, '[version]' );
+
 		return array_merge(
 			parent::get_attributes(),
 			array(
@@ -79,11 +86,13 @@ class LLMS_Blocks_Pricing_Table_Block extends LLMS_Blocks_Abstract_Block {
 	 * @since 1.0.0
 	 * @since 1.3.7 Unknown.
 	 * @since 1.9.0 Added `llms_blocks_render_pricing_table_block` filter.
+	 * @deprecated [version]
 	 *
 	 * @param array $attributes Optional. Block attributes. Default empty array.
 	 * @return void
 	 */
 	public function output( $attributes = array() ) {
+		llms_deprecated_function( __METHOD__, '[version]' );
 
 		ob_start();
 		if ( 'edit' === filter_input( INPUT_GET, 'context' ) ) {
@@ -95,7 +104,7 @@ class LLMS_Blocks_Pricing_Table_Block extends LLMS_Blocks_Abstract_Block {
 				}
 			}
 
-			// force display of the table on the admin panel.
+			// Force display of the table on the admin panel.
 			add_filter( 'llms_product_pricing_table_enrollment_status', '__return_false' );
 			add_filter( 'llms_product_is_purchasable', '__return_true' );
 
@@ -106,15 +115,21 @@ class LLMS_Blocks_Pricing_Table_Block extends LLMS_Blocks_Abstract_Block {
 		$block_content = ob_get_clean();
 
 		/**
-		 * Filters the block html
+		 * Filters the block html.
 		 *
 		 * @since 1.9.0
+		 * @deprecated [version]
 		 *
-		 * @param string                          $block_content The block's html.
-		 * @param array                           $attributes    The block's array of attributes.
-		 * @param LLMS_Blocks_Pricing_Table_Block $block         This block object.
+		 * @param string $block_content The block's html.
+		 * @param array  $attributes    The block's array of attributes.
+		 * @param self   $block         This block object.
 		 */
-		$block_content = apply_filters( 'llms_blocks_render_pricing_table_block', $block_content, $attributes, $this );
+		$block_content = apply_filters_deprecated(
+			'llms_blocks_pricing_table_block_render',
+			array( $block_content, $attributes, $this ),
+			'[version]',
+			'render_block_llms/pricing-table'
+		);
 
 		remove_filter( 'llms_product_pricing_table_enrollment_status', '__return_false' );
 		remove_filter( 'llms_product_is_purchasable', '__return_true' );
@@ -125,5 +140,3 @@ class LLMS_Blocks_Pricing_Table_Block extends LLMS_Blocks_Abstract_Block {
 
 	}
 }
-
-return new LLMS_Blocks_Pricing_Table_Block();

--- a/includes/class-llms-blocks-migrate.php
+++ b/includes/class-llms-blocks-migrate.php
@@ -163,8 +163,6 @@ class LLMS_Blocks_Migrate {
 			<?php endif; ?>
 
 <!-- wp:llms/course-continue-button -->
-<div class="wp-block-llms-course-continue-button" style="text-align:center">[lifterlms_course_continue_button]</div>
-<!-- /wp:llms/course-continue-button -->
 
 <!-- wp:llms/course-syllabus /-->
 			<?php

--- a/src/js/blocks/index.js
+++ b/src/js/blocks/index.js
@@ -15,20 +15,17 @@ import {
 	unregisterBlockType,
 } from '@wordpress/blocks';
 import { store as editorStore } from '@wordpress/editor';
-import { doAction, applyFilters } from '@wordpress/hooks';
+import { applyFilters, doAction } from '@wordpress/hooks';
 import { select } from '@wordpress/data';
 
 // Internal Deps.
 import { getCurrentPostType } from '../util/';
 
 // Standard Blocks.
-import * as courseContinueButton from './course-continue-button/';
 import * as courseInfo from './course-information/';
-import * as courseProgress from './course-progress/';
 import * as instructors from './instructors/';
 import * as lessonNavigation from './lesson-navigation/';
 import * as lessonProgression from './lesson-progression/';
-import * as pricingTable from './pricing-table/';
 import * as phpTemplate from './php-template/';
 
 // Form Field Blocks.
@@ -125,13 +122,10 @@ export default () => {
 
 	// Blocks to register.
 	const blocks = [
-		courseContinueButton,
 		courseInfo,
-		courseProgress,
 		instructors,
 		lessonNavigation,
 		lessonProgression,
-		pricingTable,
 		phpTemplate,
 	];
 

--- a/src/js/sidebar/course-builder/editor.scss
+++ b/src/js/sidebar/course-builder/editor.scss
@@ -56,7 +56,6 @@
 		font-size: 14px;
 		font-weight: 400;
 		border-radius: 2px;
-		height: 38px;
 	}
 }
 


### PR DESCRIPTION
## Description

Deprecates and unregisters old blocks that have been moved to the new shortcode blocks in core llms plugin.

Fixes #197 

## How has this been tested?

Manually

## Types of changes

Breaking change ? 

## Checklist:
- [x] This PR requires and contains at least one changelog file.
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests
- [x] My code follows the LifterLMS Coding & Documentation Standards.
