### PR TITLE
Added LifterLMS icon to LifterLMS Blocks block category.

### DIFF
--- a/.changelogs/add-icon-to-block-category.yml
+++ b/.changelogs/add-icon-to-block-category.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: added
+entry: Added LifterLMS icon to LifterLMS Blocks block category.

--- a/src/js/blocks.js
+++ b/src/js/blocks.js
@@ -8,6 +8,9 @@
 // SCSS.
 import '../scss/blocks.scss';
 
+// Icon for Block Category.
+import LifterLMSIcon from './icons/lifterlms-icon';
+
 // Internal Deps.
 import './block-visibility/';
 import './dom-ready/';
@@ -29,3 +32,12 @@ window.llms.components = {
 	...components,
 	...Components,
 };
+
+/**
+ * Add our SVG icon to the LifterLMS blocks category.
+ *
+ * @since TBD
+ */
+( function() {
+	wp.blocks.updateCategory( 'llms-blocks', { icon: LifterLMSIcon } );
+} )();


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
Added SVG icon to our blocks category. It isn't showing in the Appearance > Widgets area right now - I'm not sure if this is something with my code or something with the way we merge our blocks code into LifterLMS core and it will resolve once that's merged and built.

## How has this been tested?
Locally 

## Screenshots <!-- if applicable -->
![Screenshot 2024-03-24 at 11 42 39 AM](https://github.com/gocodebox/lifterlms-blocks/assets/5312875/426d0deb-4b34-4992-acbf-5578c651b22d)

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

