### PR TITLE
Adding the Launch Course Builder button back into the top of the course edit header

### DIFF
--- a/.changelogs/fix_show-launch-builder-in-course-edit-header.yml
+++ b/.changelogs/fix_show-launch-builder-in-course-edit-header.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#220"
+entry: Re-adds the Launch Course Builder button to the top of the Course Edit page.

--- a/src/js/sidebar/course-builder/toolbar-launch-button.jsx
+++ b/src/js/sidebar/course-builder/toolbar-launch-button.jsx
@@ -18,9 +18,16 @@ const buttonId = 'llms-launch-course-builder-top-button';
  *               WordPress is installed in a subdirectory.
  */
 export const addToolbarLaunchButton = () => {
-	const editPostHeaderToolbarLeft = document.getElementsByClassName(
+	let editPostHeaderToolbarLeft = document.getElementsByClassName(
 		'edit-post-header-toolbar__left'
 	)[ 0 ];
+
+	if ( ! editPostHeaderToolbarLeft ) {
+		// Post WP 6.5 area
+		editPostHeaderToolbarLeft = document.getElementsByClassName(
+			'editor-document-tools__left'
+		)[ 0 ];
+	}
 
 	if ( ! editPostHeaderToolbarLeft ) {
 		return;


### PR DESCRIPTION

## Description

Fixes #220 

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->

<img width="1257" alt="Captura de pantalla 2024-04-25 a las 12 44 31 p  m" src="https://github.com/gocodebox/lifterlms-blocks/assets/627497/e330628d-54d0-404a-8263-fb5021402d7d">

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

