### PR TITLE
Avoid stripping out the form html from the enroll form shown to logged in users, and block output (ie. Groups)

### DIFF
--- a/includes/blocks/class-llms-blocks-course-progress-block.php
+++ b/includes/blocks/class-llms-blocks-course-progress-block.php
@@ -82,7 +82,7 @@ class LLMS_Blocks_Course_Progress_Block extends LLMS_Blocks_Abstract_Block {
 		$block_content = apply_filters( 'llms_blocks_render_course_progress_block', $block_content, $attributes, $this );
 
 		if ( $block_content ) {
-			echo wp_kses_post( $block_content );
+			echo wp_kses( $block_content, LLMS_ALLOWED_HTML_FORM_FIELDS );
 		}
 	}
 }

--- a/includes/blocks/class-llms-blocks-php-template-block.php
+++ b/includes/blocks/class-llms-blocks-php-template-block.php
@@ -133,7 +133,7 @@ class LLMS_Blocks_PHP_Template_Block extends LLMS_Blocks_Abstract_Block {
 		$block_content = apply_filters( 'llms_blocks_render_php_template_block', $block_content, $attributes, $templates[ $attributes['template'] ], $this );
 
 		if ( $block_content ) {
-			echo wp_kses_post( $block_content );
+			echo wp_kses( $block_content, LLMS_ALLOWED_HTML_FORM_FIELDS );
 		}
 	}
 }

--- a/includes/blocks/class-llms-blocks-pricing-table-block.php
+++ b/includes/blocks/class-llms-blocks-pricing-table-block.php
@@ -119,7 +119,7 @@ class LLMS_Blocks_Pricing_Table_Block extends LLMS_Blocks_Abstract_Block {
 		remove_filter( 'llms_product_is_purchasable', '__return_true' );
 
 		if ( $block_content ) {
-			echo wp_kses_post( $block_content );
+			echo wp_kses( $block_content, LLMS_ALLOWED_HTML_FORM_FIELDS );
 		}
 	}
 }


### PR DESCRIPTION
## Description
The output for the pricing table block was using wp_kses_post vs. our allowed form HTML tags, so the form used to enroll logged in allowed users was being stripped (ie. logged in as admin, go to a course the admin is not enrolled in already that has a free access plan). This uses the form HTML instead.

This also affects the group settings form and any other blocks rendered out.

Fixes #228 and #229

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="903" alt="Captura de pantalla 2024-07-24 a las 11 46 43 a  m" src="https://github.com/user-attachments/assets/c51b5973-b889-4d51-af19-f11a0c0c29ec">
<img width="721" alt="Captura de pantalla 2024-07-29 a las 10 30 13 a  m" src="https://github.com/user-attachments/assets/1574bdf8-5713-4909-b762-c2f9d3966a91">


## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

