### PR TITLE
Fix for password confirmation field toggle

### DIFF
--- a/.changelogs/fix_password-confirmation-field-toggle.yml
+++ b/.changelogs/fix_password-confirmation-field-toggle.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#243"
+entry: Fixes unchecking the "Confirmation Field" toggle on a Password block.

--- a/src/js/blocks/form-fields/fields/confirm-group.js
+++ b/src/js/blocks/form-fields/fields/confirm-group.js
@@ -234,13 +234,18 @@ allowed.forEach( ( blockName ) => {
 		type: 'block',
 		blocks: [ blockName ],
 		isMatch: () => {
-			const { getSelectedBlock } = select( blockEditorStore ),
-				{ innerBlocks } = getSelectedBlock(),
-				controllerBlock =
-					innerBlocks[ findControllerBlockIndex( innerBlocks ) ],
-				{ name } = controllerBlock || {};
+			const { getSelectedBlock, getBlockParentsByBlockName } = select( blockEditorStore ),
+            selectedBlock = getSelectedBlock();
 
-			return name === blockName;
+			// Case 1: Confirm group itself is selected.
+			if (selectedBlock.name === name) {
+				const controllerBlock = selectedBlock.innerBlocks[findControllerBlockIndex(selectedBlock.innerBlocks)];
+				return controllerBlock?.name === blockName;
+			}
+
+			// Case 2: Inner block is selected.
+			const confirmGroupParents = getBlockParentsByBlockName(selectedBlock.clientId, name);
+			return confirmGroupParents.length > 0 && selectedBlock.name === blockName;
 		},
 		transform: ( groupAttributes, innerBlocks ) => {
 			const { llms_visibility } = groupAttributes,


### PR DESCRIPTION

## Description

We were only checking that the group itself was selected. In the case of the password confirmation field, we actually have the "Password" input selected, so we need to instead check that the selected block is within the confirm group in the `isMatch` check.

Fixes https://github.com/gocodebox/lifterlms-blocks/issues/243

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
![CleanShot 2025-01-07 at 2  38 34](https://github.com/user-attachments/assets/0baff75f-b7ad-47ad-a861-7dfd1f29b38e)

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

