### PR TITLE
Switch course information header from h3 to h2 by default.

### DIFF
--- a/.changelogs/change-default-heading-course-information-block.yml
+++ b/.changelogs/change-default-heading-course-information-block.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: Changing default heading for Course Information block for accessibility.

--- a/src/js/blocks/course-information/index.js
+++ b/src/js/blocks/course-information/index.js
@@ -56,7 +56,7 @@ export const settings = {
 		},
 		title_size: {
 			type: 'string',
-			default: 'h3',
+			default: 'h2',
 		},
 		length: {
 			type: 'string',


### PR DESCRIPTION
## Description
Switch default header from h3 to h2 for accessibility.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
![CleanShot 2025-01-17 at 9  12 08@2x](https://github.com/user-attachments/assets/54c3b421-9ff2-479b-bc0b-987d815bad82)

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

