### PR TITLE
Filter to avoid rendering blocks if we're within an Elementor or other page

### DIFF
--- a/.changelogs/elementor-lesson-and-course-updates.yml
+++ b/.changelogs/elementor-lesson-and-course-updates.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+entry: Hide gutenberg lifterlms blocks from rendering if the post or page was
+  edited using Elementor.

--- a/includes/class-llms-blocks-abstract-block.php
+++ b/includes/class-llms-blocks-abstract-block.php
@@ -60,7 +60,6 @@ abstract class LLMS_Blocks_Abstract_Block {
 		}
 
 		$this->register_meta();
-
 	}
 
 	/**
@@ -145,6 +144,10 @@ abstract class LLMS_Blocks_Abstract_Block {
 	 */
 	public function render_callback( $attributes = array(), $content = '' ) {
 
+		if ( ! apply_filters( 'llms_render_block', true, $this ) ) {
+			return '';
+		}
+
 		$this->add_hooks( $attributes, $content );
 
 		ob_start();
@@ -158,7 +161,6 @@ abstract class LLMS_Blocks_Abstract_Block {
 		}
 
 		return $ret;
-
 	}
 
 	/**
@@ -171,5 +173,4 @@ abstract class LLMS_Blocks_Abstract_Block {
 	 * @version 1.0.0
 	 */
 	public function register_meta() {}
-
 }


### PR DESCRIPTION

<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
Uses new `llms_render_block` method to conditionally render (or hide) the block.

Fixes https://github.com/gocodebox/lifterlms/issues/2886

## How has this been tested?
Manually

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

