### PR TITLE
Removing instructors from the block sidebar, allow updating of Instructors and Information blocks dynamically

### DIFF
--- a/.changelogs/moving-instructor-settings-from-blocks-1.yml
+++ b/.changelogs/moving-instructor-settings-from-blocks-1.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: changed
+entry: Updates to Instructors and Course Information blocks to refresh blocks
+  with new information when estimated time and instructors changed.

--- a/.changelogs/moving-instructor-settings-from-blocks.yml
+++ b/.changelogs/moving-instructor-settings-from-blocks.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: changed
+entry: Removing Instructors from sidebar in favor of instructors as a tab.

--- a/includes/blocks/class-llms-blocks-instructors-block.php
+++ b/includes/blocks/class-llms-blocks-instructors-block.php
@@ -76,11 +76,11 @@ class LLMS_Blocks_Instructors_Block extends LLMS_Blocks_Abstract_Block {
 			parent::get_attributes(),
 			array(
 				'post_id'  => array(
-					'type'    => 'int',
+					'type'    => 'integer',
 					'default' => 0,
 				),
 				'_refresh' => array(
-					'type'    => 'int',
+					'type'    => 'integer',
 					'default' => 0,
 				),
 			)

--- a/includes/blocks/class-llms-blocks-instructors-block.php
+++ b/includes/blocks/class-llms-blocks-instructors-block.php
@@ -60,7 +60,6 @@ class LLMS_Blocks_Instructors_Block extends LLMS_Blocks_Abstract_Block {
 		}
 
 		add_action( $this->get_render_hook(), $func, 10 );
-
 	}
 
 	/**
@@ -76,7 +75,11 @@ class LLMS_Blocks_Instructors_Block extends LLMS_Blocks_Abstract_Block {
 		return array_merge(
 			parent::get_attributes(),
 			array(
-				'post_id' => array(
+				'post_id'  => array(
+					'type'    => 'int',
+					'default' => 0,
+				),
+				'_refresh' => array(
 					'type'    => 'int',
 					'default' => 0,
 				),
@@ -95,7 +98,6 @@ class LLMS_Blocks_Instructors_Block extends LLMS_Blocks_Abstract_Block {
 	public function get_empty_render_message() {
 		return __( 'No visible instructors were found.', 'lifterlms' );
 	}
-
 }
 
 return new LLMS_Blocks_Instructors_Block();

--- a/src/js/blocks/course-information/index.js
+++ b/src/js/blocks/course-information/index.js
@@ -18,8 +18,6 @@ import PreviewTerms from './preview-terms';
 import { RichText } from '@wordpress/block-editor';
 import { Fragment } from '@wordpress/element';
 import { useEntityProp } from '@wordpress/core-data';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 // Internal dependencies.

--- a/src/js/blocks/course-information/index.js
+++ b/src/js/blocks/course-information/index.js
@@ -40,41 +40,6 @@ export const name = 'llms/course-information';
 export const postTypes = [ 'course' ];
 
 /**
- * Refresh the post entity after a legacy meta-box save.
- */
-function useRefreshAfterMetaboxSave() {
-	const metaSaving = useSelect(
-		( select ) => select( 'core/edit-post' ).isSavingMetaBoxes(),
-		[]
-	);
-
-	const { invalidateResolution } = useDispatch( 'core' );
-
-	const postType = useSelect(
-		( select ) => select( 'core/editor' ).getCurrentPostType(),
-		[]
-	);
-	const postId = useSelect(
-		( select ) => select( 'core/editor' ).getCurrentPostId(),
-		[]
-	);
-
-	// remember previous value so we can detect the "falling edge".
-	const wasSavingRef = useRef( metaSaving );
-
-	useEffect( () => {
-		if ( wasSavingRef.current && ! metaSaving ) {
-			// legacy save just finished → bust the cache, forcing a fresh REST fetch.
-			invalidateResolution(
-				'getEntityRecord',
-				[ 'postType', postType, postId ]
-			);
-		}
-		wasSavingRef.current = metaSaving;
-	}, [ metaSaving, invalidateResolution, postType, postId ] );
-}
-
-/**
  * Register: Course Information Block
  *
  * @since 2.5.0 Update icon color to `currentColor`.
@@ -138,8 +103,6 @@ export const settings = {
 	 * @return {Fragment} Component HTML Fragment.
 	 */
 	edit: ( props ) => {
-		useRefreshAfterMetaboxSave();
-
 		const [ meta ] = useEntityProp( 'postType', 'course', 'meta' );
 		const length = meta?._llms_length || '';
 

--- a/src/js/blocks/course-information/index.js
+++ b/src/js/blocks/course-information/index.js
@@ -17,6 +17,9 @@ import PreviewTerms from './preview-terms';
 // External Deps.
 import { RichText } from '@wordpress/block-editor';
 import { Fragment } from '@wordpress/element';
+import { useEntityProp } from '@wordpress/core-data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 // Internal dependencies.
@@ -35,6 +38,41 @@ export const name = 'llms/course-information';
  * @type {Array}
  */
 export const postTypes = [ 'course' ];
+
+/**
+ * Refresh the post entity after a legacy meta-box save.
+ */
+function useRefreshAfterMetaboxSave() {
+	const metaSaving = useSelect(
+		( select ) => select( 'core/edit-post' ).isSavingMetaBoxes(),
+		[]
+	);
+
+	const { invalidateResolution } = useDispatch( 'core' );
+
+	const postType = useSelect(
+		( select ) => select( 'core/editor' ).getCurrentPostType(),
+		[]
+	);
+	const postId = useSelect(
+		( select ) => select( 'core/editor' ).getCurrentPostId(),
+		[]
+	);
+
+	// remember previous value so we can detect the "falling edge".
+	const wasSavingRef = useRef( metaSaving );
+
+	useEffect( () => {
+		if ( wasSavingRef.current && ! metaSaving ) {
+			// legacy save just finished → bust the cache, forcing a fresh REST fetch.
+			invalidateResolution(
+				'getEntityRecord',
+				[ 'postType', postType, postId ]
+			);
+		}
+		wasSavingRef.current = metaSaving;
+	}, [ metaSaving, invalidateResolution, postType, postId ] );
+}
 
 /**
  * Register: Course Information Block
@@ -100,9 +138,13 @@ export const settings = {
 	 * @return {Fragment} Component HTML Fragment.
 	 */
 	edit: ( props ) => {
+		useRefreshAfterMetaboxSave();
+
+		const [ meta ] = useEntityProp( 'postType', 'course', 'meta' );
+		const length = meta?._llms_length || '';
+
 		const { attributes, setAttributes } = props;
 		const {
-			length,
 			show_cats,
 			show_difficulty,
 			show_length,

--- a/src/js/blocks/instructors/index.js
+++ b/src/js/blocks/instructors/index.js
@@ -73,11 +73,11 @@ export const settings = {
 	],
 	attributes: {
 		post_id: {
-			type: 'int',
+			type: 'integer',
 			default: 0,
 		},
 		_refresh: {
-			type: 'int',
+			type: 'integer',
 			default: 0,
 		}
 	},

--- a/src/js/blocks/instructors/index.js
+++ b/src/js/blocks/instructors/index.js
@@ -17,6 +17,8 @@ import icon from '../../icons/person-chalkboard';
 import edit from './edit';
 import './editor.scss';
 
+import { subscribe, select, dispatch } from '@wordpress/data';
+
 /**
  * Block Name
  *
@@ -31,6 +33,27 @@ export const name = 'llms/instructors';
  */
 export const postTypes = [ 'course', 'llms_membership' ];
 
+let wasSaving = false;
+
+subscribe( () => {
+	const isSaving = select( 'core/edit-post' ).isSavingMetaBoxes();
+
+	if ( wasSaving && ! isSaving ) {
+		wasSaving = isSaving;
+
+		select( 'core/block-editor' )
+			.getBlocks()
+			.filter( ( b ) => b.name === name )
+			.forEach( ( b ) =>
+				dispatch( 'core/block-editor' ).updateBlockAttributes(
+					b.clientId,
+					{ _refresh: Date.now() }
+				)
+			);
+	} else {
+		wasSaving = isSaving;
+	}
+} );
 /**
  * Register Block.
  *
@@ -53,6 +76,10 @@ export const settings = {
 			type: 'int',
 			default: 0,
 		},
+		_refresh: {
+			type: 'int',
+			default: 0,
+		}
 	},
 
 	edit,

--- a/src/js/sidebar/index.js
+++ b/src/js/sidebar/index.js
@@ -47,7 +47,6 @@ const Sidebar = () => {
 		</PluginSidebarMoreMenuItem>
 		<PluginSidebar name="llms-sidebar" title="LifterLMS">
 			{ [ 'course', 'lesson' ].includes( postType ) && <CourseBuilderPanel /> }
-			{ [ 'course', 'llms_membership' ].includes( postType ) && <Instructors /> }
 		</PluginSidebar>
 	</>;
 };

--- a/src/js/sidebar/index.js
+++ b/src/js/sidebar/index.js
@@ -45,9 +45,9 @@ const Sidebar = () => {
 		>
 			{ 'LifterLMS' }
 		</PluginSidebarMoreMenuItem>
-		<PluginSidebar name="llms-sidebar" title="LifterLMS">
-			{ [ 'course', 'lesson' ].includes( postType ) && <CourseBuilderPanel /> }
-		</PluginSidebar>
+		{ [ 'lesson', 'course' ].includes( postType ) && <PluginSidebar name="llms-sidebar" title="LifterLMS">
+			<CourseBuilderPanel />
+		</PluginSidebar> }
 	</>;
 };
 


### PR DESCRIPTION

## Description
Moving instructor management in the block editor to a new Instructors tab.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
![CleanShot 2025-05-15 at 5  05 46@2x](https://github.com/user-attachments/assets/7a098dda-5a5c-4ae0-8fd6-17a642b152c5)

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

