### PR TITLE
Fixing refresh autosave error

### DIFF
--- a/.changelogs/fixing-refresh-autosave-error.yml
+++ b/.changelogs/fixing-refresh-autosave-error.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Avoid unsaved changes warning with the course instructors block.

--- a/includes/blocks/class-llms-blocks-instructors-block.php
+++ b/includes/blocks/class-llms-blocks-instructors-block.php
@@ -75,11 +75,7 @@ class LLMS_Blocks_Instructors_Block extends LLMS_Blocks_Abstract_Block {
 		return array_merge(
 			parent::get_attributes(),
 			array(
-				'post_id'  => array(
-					'type'    => 'integer',
-					'default' => 0,
-				),
-				'_refresh' => array(
+				'post_id' => array(
 					'type'    => 'integer',
 					'default' => 0,
 				),

--- a/src/js/blocks/instructors/edit.js
+++ b/src/js/blocks/instructors/edit.js
@@ -30,7 +30,21 @@ class InstructorsEdit extends Component {
 
 		this.state = {
 			instructors: this.props.instructors,
+			// Used to force a remount of <ServerSideRender /> after a save finishes.
+			ssrNonce: 0,
 		};
+	}
+
+	/**
+	 * When a save transitions from "saving" -> "not saving", bump the nonce
+	 * so the SSR component remounts and refetches fresh HTML.
+	 *
+	 * @param {Object} prevProps
+	 */
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.isSavingPost && ! this.props.isSavingPost ) {
+			this.setState( { ssrNonce: Date.now() } );
+		}
 	}
 
 	/**
@@ -42,15 +56,15 @@ class InstructorsEdit extends Component {
 	 */
 	render = () => {
 		const { name, attributes, post_id } = this.props; // eslint-disable-line camelcase
+		const { ssrNonce } = this.state;
 
 		return (
 			<Fragment>
 				<ServerSideRender
+					key={ ssrNonce } // remount -> refetch on save complete
 					block={ name }
 					attributes={ attributes }
-					urlQueryArgs={ {
-						post_id,
-					} }
+					urlQueryArgs={ { post_id } }
 				/>
 			</Fragment>
 		);
@@ -66,12 +80,13 @@ class InstructorsEdit extends Component {
  */
 export default compose( [
 	withSelect( ( select ) => {
-		const { getEditedPostAttribute, getCurrentPostId } = select(
-			'core/editor'
-		);
+		const { getEditedPostAttribute, getCurrentPostId, isSavingPost } =
+			select( 'core/editor' );
+
 		return {
 			post_id: getCurrentPostId(),
 			instructors: getEditedPostAttribute( 'instructors' ),
+			isSavingPost: isSavingPost(),
 		};
 	} ),
 ] )( InstructorsEdit );

--- a/src/js/blocks/instructors/index.js
+++ b/src/js/blocks/instructors/index.js
@@ -33,27 +33,6 @@ export const name = 'llms/instructors';
  */
 export const postTypes = [ 'course', 'llms_membership' ];
 
-let wasSaving = false;
-
-subscribe( () => {
-	const isSaving = select( 'core/edit-post' ).isSavingMetaBoxes();
-
-	if ( wasSaving && ! isSaving ) {
-		wasSaving = isSaving;
-
-		select( 'core/block-editor' )
-			.getBlocks()
-			.filter( ( b ) => b.name === name )
-			.forEach( ( b ) =>
-				dispatch( 'core/block-editor' ).updateBlockAttributes(
-					b.clientId,
-					{ _refresh: Date.now() }
-				)
-			);
-	} else {
-		wasSaving = isSaving;
-	}
-} );
 /**
  * Register Block.
  *
@@ -73,10 +52,6 @@ export const settings = {
 	],
 	attributes: {
 		post_id: {
-			type: 'integer',
-			default: 0,
-		},
-		_refresh: {
 			type: 'integer',
 			default: 0,
 		}


### PR DESCRIPTION


## Description
Avoid a warning and autosave when updating the instructors block, by using a non-persistent value in the JS to refresh the ServerSideRender.

## How has this been tested?
Manually

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

