### PR TITLE
Removing the estimated completion time box from the block.

### DIFF
--- a/.changelogs/remove-estimated-completion-time.yml
+++ b/.changelogs/remove-estimated-completion-time.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: removed
+entry: Removing "Estimated Completion Time" from the Course Inforamtion block,
+  as it was moved to General course options tab.

--- a/src/js/blocks/course-information/inspect.js
+++ b/src/js/blocks/course-information/inspect.js
@@ -61,18 +61,6 @@ export default class Inspector extends Component {
 						] }
 					/>
 
-					<TextControl
-						label={ __( 'Estimated Completion Time', 'lifterlms' ) }
-						value={ length }
-						onChange={ ( value ) =>
-							setAttributes( { length: value } )
-						}
-						help={ __(
-							'How many hours, days, weeks, etc… should a student expect to spend in order to complete this course.',
-							'lifterlms'
-						) }
-					/>
-
 					<ToggleControl
 						label={ __( 'Display Estimated Time', 'lifterlms' ) }
 						checked={ !! show_length }


### PR DESCRIPTION

## Description

Fixes https://github.com/gocodebox/lifterlms/issues/3016 once blocks version is updated

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="3308" height="1814" alt="CleanShot 2025-10-30 at 13 02 40@2x" src="https://github.com/user-attachments/assets/5b8e0d07-ef5e-40c5-a9ef-a09d1e307f6f" />

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

