### PR TITLE
Parent course block

### DIFF
--- a/.changelogs/parent-course-block.yml
+++ b/.changelogs/parent-course-block.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: added
+entry: New "parent course" block for a "Back to <course>" link.

--- a/includes/blocks/class-llms-blocks-parent-course-block.php
+++ b/includes/blocks/class-llms-blocks-parent-course-block.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Parent Course (Back to Course) block.
+ *
+ * @package LifterLMS_Blocks/Blocks
+ *
+ * @since [version]
+ * @version [version]
+ *
+ * @render_hook llms_parent-course_block_render
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Parent Course block class.
+ *
+ * Renders a "Back to: Course Name" link using the existing
+ * `lifterlms_template_single_parent_course()` template function.
+ *
+ * @since [version]
+ */
+class LLMS_Blocks_Parent_Course_Block extends LLMS_Blocks_Abstract_Block {
+
+	/**
+	 * Block ID.
+	 *
+	 * @var string
+	 */
+	protected $id = 'parent-course';
+
+	/**
+	 * Is block dynamic (rendered in PHP).
+	 *
+	 * @var bool
+	 */
+	protected $is_dynamic = true;
+
+	/**
+	 * Add actions attached to the render function action.
+	 *
+	 * @since [version]
+	 *
+	 * @param array  $attributes Optional. Block attributes. Default empty array.
+	 * @param string $content    Optional. Block content. Default empty string.
+	 * @return void
+	 */
+	public function add_hooks( $attributes = array(), $content = '' ) {
+
+		add_action( $this->get_render_hook(), array( $this, 'output' ), 10 );
+	}
+
+	/**
+	 * Output the parent course link.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $attributes Optional. Block attributes. Default empty array.
+	 * @return void
+	 */
+	public function output( $attributes = array() ) {
+
+		ob_start();
+		lifterlms_template_single_parent_course();
+		$html = ob_get_clean();
+
+		if ( $html ) {
+			$class = empty( $attributes['className'] ) ? '' : ' ' . esc_attr( $attributes['className'] );
+			printf(
+				'<div class="wp-block-%1$s-%2$s%3$s">%4$s</div>',
+				$this->vendor,
+				$this->id,
+				$class,
+				$html
+			);
+		}
+	}
+}
+
+return new LLMS_Blocks_Parent_Course_Block();

--- a/includes/class-llms-blocks.php
+++ b/includes/class-llms-blocks.php
@@ -153,6 +153,7 @@ class LLMS_Blocks {
 		require_once LLMS_BLOCKS_PLUGIN_DIR . '/includes/blocks/class-llms-blocks-course-progress-block.php';
 		require_once LLMS_BLOCKS_PLUGIN_DIR . '/includes/blocks/class-llms-blocks-instructors-block.php';
 		require_once LLMS_BLOCKS_PLUGIN_DIR . '/includes/blocks/class-llms-blocks-lesson-navigation-block.php';
+		require_once LLMS_BLOCKS_PLUGIN_DIR . '/includes/blocks/class-llms-blocks-parent-course-block.php';
 		require_once LLMS_BLOCKS_PLUGIN_DIR . '/includes/blocks/class-llms-blocks-lesson-progression-block.php';
 		require_once LLMS_BLOCKS_PLUGIN_DIR . '/includes/blocks/class-llms-blocks-pricing-table-block.php';
 		require_once LLMS_BLOCKS_PLUGIN_DIR . '/includes/blocks/class-llms-blocks-php-template-block.php';

--- a/src/js/blocks/index.js
+++ b/src/js/blocks/index.js
@@ -28,6 +28,7 @@ import * as courseProgress from './course-progress/';
 import * as instructors from './instructors/';
 import * as lessonNavigation from './lesson-navigation/';
 import * as lessonProgression from './lesson-progression/';
+import * as parentCourse from './parent-course/';
 import * as pricingTable from './pricing-table/';
 import * as phpTemplate from './php-template/';
 
@@ -131,6 +132,7 @@ export default () => {
 		instructors,
 		lessonNavigation,
 		lessonProgression,
+		parentCourse,
 		pricingTable,
 		phpTemplate,
 	];

--- a/src/js/blocks/parent-course/index.js
+++ b/src/js/blocks/parent-course/index.js
@@ -1,0 +1,79 @@
+/**
+ * BLOCK: llms/parent-course
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+// WP Deps.
+import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
+import ServerSideRender from '@wordpress/server-side-render';
+
+// Internal dependencies.
+	import icon from '../../icons/arrow-left';
+
+/**
+ * Block Name
+ *
+ * @type {string}
+ */
+export const name = 'llms/parent-course';
+
+/**
+ * Register Block
+ *
+ * @since [version]
+ *
+ * @type {Object}
+ */
+export const settings = {
+	title: __( 'Back to Course', 'lifterlms' ),
+	icon: icon,
+	category: 'llms-blocks',
+	keywords: [
+		__( 'LifterLMS', 'lifterlms' ),
+		__( 'course', 'lifterlms' ),
+		__( 'parent', 'lifterlms' ),
+	],
+
+	/**
+	 * Block edit component.
+	 *
+	 * @since [version]
+	 *
+	 * @param {Object} props Block properties.
+	 * @return {Fragment} Edit component html fragment.
+	 */
+	edit( props ) {
+		const { attributes } = props;
+
+		return (
+			<Fragment>
+				<ServerSideRender
+					block={ name }
+					attributes={ attributes }
+					EmptyResponsePlaceholder={ () => (
+						<p className="llms-block-empty">
+							{ __(
+								'Back to: (Parent Course) — visible on lessons only.',
+								'lifterlms'
+							) }
+						</p>
+					) }
+				/>
+			</Fragment>
+		);
+	},
+
+	/**
+	 * Save block content.
+	 *
+	 * @since [version]
+	 *
+	 * @return {null} Saving disabled for dynamic block.
+	 */
+	save() {
+		return null;
+	},
+};

--- a/src/js/blocks/parent-course/index.js
+++ b/src/js/blocks/parent-course/index.js
@@ -11,7 +11,7 @@ import { Fragment } from '@wordpress/element';
 import ServerSideRender from '@wordpress/server-side-render';
 
 // Internal dependencies.
-	import icon from '../../icons/arrow-left';
+	import icon from '../../icons/house';
 
 /**
  * Block Name

--- a/src/js/icons/arrow-left.jsx
+++ b/src/js/icons/arrow-left.jsx
@@ -1,0 +1,12 @@
+// WordPress dependencies.
+import { SVG, Path } from '@wordpress/primitives';
+
+export default (
+	<SVG
+		className="llms-block-icon"
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 448 512"
+	>
+		<Path d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.2 288 416 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-306.7 0L214.6 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z" />
+	</SVG>
+);


### PR DESCRIPTION

## Description
Adds new "parent course" or "back to <course>" block used in the Focus Mode feature template.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="1696" height="388" alt="CleanShot 2026-03-09 at 14 59 32@2x" src="https://github.com/user-attachments/assets/8e2a9808-f188-4605-818b-bf462a9b7d0a" />

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

