### PR TITLE
Fix error with "your site doesn't include support for..." when editing a block template

### DIFF
--- a/.changelogs/fix_template-error-block-not-found.yml
+++ b/.changelogs/fix_template-error-block-not-found.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Avoid "block not found" error in the theme template editor.

--- a/src/js/blocks/index.js
+++ b/src/js/blocks/index.js
@@ -156,7 +156,7 @@ export default () => {
 
 	blocks.forEach( ( block ) => {
 		const { name, postTypes, settings } = block;
-		if ( ! postTypes || -1 !== postTypes.indexOf( postType ) ) {
+		if ( ! postTypes || ! postType || -1 !== postTypes.indexOf( postType ) ) {
 			registerBlockType( name, settings );
 		}
 	} );


### PR DESCRIPTION

## Description
When editing some templates you get a "your site doesn't include support" error but it does exist and render when the post is actually loaded.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="4054" height="820" alt="CleanShot 2026-03-09 at 14 54 59@2x" src="https://github.com/user-attachments/assets/e56714c0-107e-44b2-bb4f-04546f282ca8" />
<img width="3824" height="1126" alt="CleanShot 2026-03-09 at 14 56 14@2x" src="https://github.com/user-attachments/assets/d1b90445-7d56-4fca-a436-ca98ee6e221b" />

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

